### PR TITLE
Add simulation control core, master server, and client terminal modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # Output of the go coverage tool
 *.out
 *.cover
+coverage.html
 
 # Go workspace file
 go.work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,12 +155,14 @@ make build-linux-arm64
 ## Implementation Phases
 
 - [x] **Phase 1:** Foundation (config, database, TUI shell)
-- [ ] **Phase 2:** Population module MVP (residents, households, CRUD)
-- [ ] **Phase 3:** Resource management (inventory, consumption, rationing)
-- [ ] **Phase 4:** Facility operations (systems, maintenance)
-- [ ] **Phase 5:** Simulation engine (time, events, degradation)
+- [x] **Phase 2:** Population module MVP (residents, households, CRUD)
+- [x] **Phase 3:** Resource management (inventory, consumption, rationing)
+- [x] **Phase 4:** Facility operations (systems, maintenance)
+- [x] **Phase 5:** Simulation control core (time, consumption, degradation, incidents, demographics) + master/client deployment + web console
 - [ ] **Phase 6:** Remaining modules (labor, medical, security, governance)
 - [ ] **Phase 7:** Polish (dashboard, alerts, optimization)
+
+See [docs/SIMULATION.md](docs/SIMULATION.md) and [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the control core and client/master-server deployment.
 
 ## Key Design Decisions
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VT-UOS Makefile
 # Build automation for Vault-Tec Unified Operating System
 
-.PHONY: all build build-pi build-pi-zero test test-integration lint clean run migrate seed help
+.PHONY: all build build-pi build-pi-zero test test-integration lint clean run serve connect migrate seed help
 
 # Build variables
 BINARY_NAME := vtuos
@@ -87,10 +87,21 @@ fmt:
 	go fmt ./...
 	goimports -w .
 
-# Run the application
+# Run the application (local operator console)
 run: build
 	@echo "Running $(BINARY_NAME)..."
 	./bin/$(BINARY_NAME)
+
+# Run as the master server (authoritative core + API + web console)
+serve: build
+	@echo "Starting VT-UOS master server (web console on :8080)..."
+	./bin/$(BINARY_NAME) serve
+
+# Connect a client display terminal to a master (set ADDR=host:port)
+connect: build
+	@echo "Connecting terminal to master at $(ADDR)..."
+	@if [ -z "$(ADDR)" ]; then echo "Error: ADDR not set (e.g. make connect ADDR=127.0.0.1:8080)"; exit 1; fi
+	./bin/$(BINARY_NAME) connect $(ADDR)
 
 # Run database migrations
 migrate:
@@ -162,7 +173,9 @@ help:
 	@echo "Other targets:"
 	@echo "  lint           Run golangci-lint"
 	@echo "  fmt            Format code with gofmt and goimports"
-	@echo "  run            Build and run the application"
+	@echo "  run            Build and run the local operator console"
+	@echo "  serve          Build and run the master server + web console"
+	@echo "  connect ADDR=  Build and connect a client terminal to a master"
 	@echo "  migrate        Run database migrations"
 	@echo "  seed           Generate seed data"
 	@echo "  clean          Remove build artifacts"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,16 +1,42 @@
 # VT-UOS Development Progress
 
-**Last Updated:** 2025-12-28
+**Last Updated:** 2026-06-25
 
 ## Current Status
 
-**Phase 3: Resource Management - COMPLETE**
+**Phase 5: Simulation Control Core - COMPLETE**
 
-Ready to begin **Phase 4: Facility Operations**
+The vault now runs as authoritative operations software: a deterministic engine
+advances time and drives real consumption, production, facility degradation,
+maintenance, operational incidents, and demographics against the database. It is
+deployable as a master server with an embedded web administration console and
+managed client display/operator terminals.
+
+- **Simulation control core** (`internal/simulation`) — see [docs/SIMULATION.md](docs/SIMULATION.md)
+- **Master server + web console** (`internal/server`) — see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)
+- **Client terminals** (`internal/client`) — `vtuos connect`
+- **Operator surfaces** — Simulation Control view (F11), live-wired dashboard,
+  optional boot/attract/kiosk exhibit mode
 
 ---
 
 ## Completed Phases
+
+### Phase 5: Simulation Control Core ✅
+- Deterministic tick engine: consumption (FIFO), production, expiration,
+  facility degradation, maintenance sweep, weighted operational incidents,
+  demographics (births/deaths)
+- Persistence to `simulation_events` + `audit_log`; power-loss continuity via
+  `vault_metadata`; snapshot (`VACUUM INTO`) + `--restore` reset
+- Self-healing core facility systems (`EnsureCoreSystems`)
+- `protocol.VaultState` snapshot published to TUI, web console, and clients
+- Master server: stdlib `net/http` JSON API, SSE stream, health endpoint,
+  token-gated control, client registry with telemetry + remote operations,
+  embedded `html/template` web console
+- Client terminal: registers, streams/renders live state, reports telemetry,
+  executes remote ops; kiosk lockout + auto-reconnect
+- TUI: Simulation Control view, live dashboard, boot/attract/kiosk exhibit mode
+- Subcommands: `serve`, `connect`, default local console
 
 ### Phase 1: Foundation ✅
 - Configuration loading (TOML)

--- a/README.md
+++ b/README.md
@@ -80,9 +80,19 @@ make build
 # Run with seed data (first time)
 ./bin/vtuos --seed
 
-# Run normally
+# Run the local operator console
 ./bin/vtuos
+
+# Or run as an interactive-exhibit master server (web console on :8080)
+./bin/vtuos serve --token overseer-secret
+
+# …and connect display terminals to it
+./bin/vtuos connect 127.0.0.1:8080
 ```
+
+See **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** for the master/client topology
+and web console, and **[docs/SIMULATION.md](docs/SIMULATION.md)** for the
+simulation control core.
 
 ### First Launch
 
@@ -100,8 +110,12 @@ On first run, VT-UOS will:
 | `F2` | Dashboard |
 | `F3` | Population Registry |
 | `F4` | Resource Management |
-| `F5` | Facility Operations (coming soon) |
+| `F5` | Facility Operations |
+| `F11` | Simulation Control Core |
 | `F10` | Quit |
+
+In the **Simulation Control** view: `Space` play/pause, `+`/`-` time scale,
+`s` step a day, `h` step an hour, `k` snapshot, `a` acknowledge alerts.
 
 ## 🏗️ Architecture
 
@@ -143,19 +157,21 @@ Comprehensive documentation is available in the [`docs/`](docs/) directory:
 
 - **[DATABASE.md](docs/DATABASE.md)** - Complete SQLite schema with all tables, indexes, and business rules
 - **[MODULES.md](docs/MODULES.md)** - Service specifications, algorithms, and API interfaces
+- **[SIMULATION.md](docs/SIMULATION.md)** - Simulation control core: processing model, incidents, alerts, control API
+- **[DEPLOYMENT.md](docs/DEPLOYMENT.md)** - Local / master-server / client modes, HTTP API, web console, exhibit kiosk
 - **[TUI.md](docs/TUI.md)** - UI design, components, navigation, and key bindings
 - **[CONFIGURATION.md](docs/CONFIGURATION.md)** - Setup, config files, and environment variables
 - **[DEVELOPMENT.md](docs/DEVELOPMENT.md)** - Workflow, testing, build system, and guidelines
 
 ## 🗺️ Roadmap
 
-### Current Status: **Phase 3 Complete** 🎉
+### Current Status: **Phase 5 Complete** 🎉
 
 - [x] **Phase 1**: Foundation (config, database, TUI shell)
 - [x] **Phase 2**: Population module MVP (residents, households, CRUD)
 - [x] **Phase 3**: Resource management (inventory, consumption, rationing)
-- [ ] **Phase 4**: Facility operations (systems, maintenance) ← **In Progress**
-- [ ] **Phase 5**: Simulation engine (time, events, degradation)
+- [x] **Phase 4**: Facility operations (systems, maintenance)
+- [x] **Phase 5**: Simulation control core + master/client deployment + web console
 - [ ] **Phase 6**: Additional modules (labor, medical, security, governance)
 - [ ] **Phase 7**: Polish (dashboard, alerts, optimization)
 

--- a/cmd/vtuos/main.go
+++ b/cmd/vtuos/main.go
@@ -60,6 +60,7 @@ func signalContext() (context.Context, context.CancelFunc) {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigChan
+		signal.Stop(sigChan) // deregister; the goroutine exits after cancelling
 		slog.Info("received shutdown signal", "signal", sig)
 		cancel()
 		time.AfterFunc(10*time.Second, func() {

--- a/cmd/vtuos/main.go
+++ b/cmd/vtuos/main.go
@@ -2,6 +2,12 @@
 //
 // A mission-critical vault population management and operations system
 // designed for multi-generational underground survival.
+//
+// The single binary runs in three modes:
+//
+//	vtuos                 local operator console (TUI + in-process control core)
+//	vtuos serve           master server (authoritative core + API + web console)
+//	vtuos connect <addr>  client display/operator terminal for a master
 package main
 
 import (
@@ -12,12 +18,16 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/vtuos/vtuos/internal/client"
 	"github.com/vtuos/vtuos/internal/config"
 	"github.com/vtuos/vtuos/internal/database"
 	"github.com/vtuos/vtuos/internal/database/seed"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/server"
 	"github.com/vtuos/vtuos/internal/simulation"
 	"github.com/vtuos/vtuos/internal/tui"
 	"github.com/vtuos/vtuos/internal/util"
@@ -30,259 +40,385 @@ var (
 )
 
 func main() {
-	// Parse command line flags
-	var (
-		configPath  = flag.String("config", "", "Path to configuration file")
-		migrateOnly = flag.Bool("migrate-only", false, "Run migrations and exit")
-		seedData    = flag.Bool("seed", false, "Generate seed data")
-		showVersion = flag.Bool("version", false, "Show version and exit")
-		debugMode   = flag.Bool("debug", false, "Enable debug logging")
-		restorePath = flag.String("restore", "", "Restore the vault database from a snapshot file before starting")
-	)
-	flag.Parse()
-
-	// Show version
-	if *showVersion {
-		fmt.Printf("VT-UOS version %s (built %s)\n", Version, BuildTime)
-		os.Exit(0)
+	// Dispatch subcommands before global flag parsing.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "serve":
+			os.Exit(serveMain(os.Args[2:]))
+		case "connect":
+			os.Exit(connectMain(os.Args[2:]))
+		}
 	}
+	os.Exit(localMain(os.Args[1:]))
+}
 
-	// Setup context with cancellation
+// signalContext returns a context cancelled on SIGINT/SIGTERM with a hard exit
+// backstop if shutdown stalls.
+func signalContext() (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Handle shutdown signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
 	go func() {
 		sig := <-sigChan
 		slog.Info("received shutdown signal", "signal", sig)
 		cancel()
-
-		// Force exit after timeout
 		time.AfterFunc(10*time.Second, func() {
 			slog.Error("forced shutdown after timeout")
 			os.Exit(1)
 		})
 	}()
-
-	// Run the application
-	if err := run(ctx, *configPath, *migrateOnly, *seedData, *debugMode, *restorePath); err != nil {
-		slog.Error("application error", "error", err)
-		os.Exit(1)
-	}
+	return ctx, cancel
 }
 
-func run(ctx context.Context, configPath string, migrateOnly, seedData, debugMode bool, restorePath string) error {
-	// Load configuration
+// ----- Local operator console -----
+
+func localMain(args []string) int {
+	fs := flag.NewFlagSet("vtuos", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to configuration file")
+	migrateOnly := fs.Bool("migrate-only", false, "Run migrations and exit")
+	seedData := fs.Bool("seed", false, "Generate seed data")
+	showVersion := fs.Bool("version", false, "Show version and exit")
+	debugMode := fs.Bool("debug", false, "Enable debug logging")
+	restorePath := fs.String("restore", "", "Restore the vault database from a snapshot file before starting")
+	_ = fs.Parse(args)
+
+	if *showVersion {
+		fmt.Printf("VT-UOS version %s (built %s)\n", Version, BuildTime)
+		return 0
+	}
+
+	ctx, cancel := signalContext()
+	defer cancel()
+
+	if err := runLocal(ctx, *configPath, *migrateOnly, *seedData, *debugMode, *restorePath); err != nil {
+		slog.Error("application error", "error", err)
+		return 1
+	}
+	return 0
+}
+
+func runLocal(ctx context.Context, configPath string, migrateOnly, seedData, debugMode bool, restorePath string) error {
+	cfg, db, closeFn, err := prepare(ctx, configPath, debugMode, restorePath)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	if migrateOnly {
+		slog.Info("migrations complete, exiting")
+		return nil
+	}
+	if seedData {
+		return runSeed(ctx, cfg, db)
+	}
+
+	clock := newClock(cfg)
+	engine := simulation.New(db, cfg, clock)
+	if err := engine.Start(ctx); err != nil {
+		slog.Warn("simulation control core failed to start", "error", err)
+	}
+	defer stopEngine(engine)
+
+	tui.Version = Version
+	tui.BuildTime = BuildTime
+	slog.Info("starting local console", "vault", cfg.Vault.Designation, "simulation", cfg.Simulation.Enabled)
+	if err := tui.RunWithEngine(ctx, db, cfg, clock, engine); err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+	slog.Info("VT-UOS shutdown complete")
+	return nil
+}
+
+// ----- Master server -----
+
+func serveMain(args []string) int {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to configuration file")
+	debugMode := fs.Bool("debug", false, "Enable debug logging")
+	listen := fs.String("listen", "", "Override the server listen address (e.g. :8080)")
+	token := fs.String("token", "", "Override the operator admin token")
+	restorePath := fs.String("restore", "", "Restore the vault database from a snapshot file before starting")
+	_ = fs.Parse(args)
+
+	ctx, cancel := signalContext()
+	defer cancel()
+
+	cfg, db, closeFn, err := prepare(ctx, *configPath, *debugMode, *restorePath)
+	if err != nil {
+		slog.Error("serve setup failed", "error", err)
+		return 1
+	}
+	defer closeFn()
+
+	if *listen != "" {
+		cfg.Server.Listen = *listen
+	}
+	if *token != "" {
+		cfg.Server.AdminToken = *token
+	}
+
+	clock := newClock(cfg)
+	engine := simulation.New(db, cfg, clock)
+	if err := engine.Start(ctx); err != nil {
+		slog.Warn("simulation control core failed to start", "error", err)
+	}
+	defer stopEngine(engine)
+
+	srv, err := server.New(engine, cfg)
+	if err != nil {
+		slog.Error("creating server failed", "error", err)
+		return 1
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		if err != nil {
+			slog.Error("server stopped", "error", err)
+			return 1
+		}
+	}
+
+	shutCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+	defer c()
+	_ = srv.Shutdown(shutCtx)
+	slog.Info("master server shutdown complete")
+	return 0
+}
+
+// ----- Client terminal -----
+
+func connectMain(args []string) int {
+	fs := flag.NewFlagSet("connect", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to configuration file")
+	name := fs.String("name", "", "Terminal display name reported to the master")
+	kind := fs.String("kind", "", "Terminal kind: display or operator")
+	debugMode := fs.Bool("debug", false, "Enable debug logging")
+	_ = fs.Parse(args)
+
+	addr := fs.Arg(0)
+	if addr == "" {
+		fmt.Fprintln(os.Stderr, "usage: vtuos connect [flags] <master-address>")
+		return 2
+	}
+
+	cfg, _, err := config.Load(*configPath, true)
+	if err != nil {
+		cfg = config.Default()
+	}
+	closeLog := setupClientLogging(cfg, *debugMode)
+	defer closeLog()
+
+	ctx, cancel := signalContext()
+	defer cancel()
+
+	terminalName := firstNonEmpty(*name, cfg.Client.Name, "vtuos-terminal")
+	terminalKind := protocol.ClientDisplay
+	if strings.EqualFold(*kind, "operator") || strings.EqualFold(cfg.Client.Kind, "operator") {
+		terminalKind = protocol.ClientOperator
+	}
+
+	conn := client.NewConn(addr, terminalName, terminalKind, Version)
+	if err := client.Run(ctx, conn, cfg); err != nil {
+		slog.Error("client terminal error", "error", err)
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+	return 0
+}
+
+// ----- Shared setup -----
+
+// prepare loads configuration, configures logging, opens (optionally restoring
+// and recovering) the database, and applies migrations. The returned closeFn
+// releases the database and any log file.
+func prepare(ctx context.Context, configPath string, debug bool, restorePath string) (*config.Config, *database.DB, func(), error) {
 	cfg, cfgPath, err := config.Load(configPath, true)
 	if err != nil {
-		return fmt.Errorf("loading configuration: %w", err)
+		return nil, nil, nil, fmt.Errorf("loading configuration: %w", err)
 	}
 
-	// Setup logging
-	logLevel := slog.LevelInfo
-	if debugMode {
-		logLevel = slog.LevelDebug
-	} else {
-		switch cfg.Logging.Level {
-		case config.LogLevelDebug:
-			logLevel = slog.LevelDebug
-		case config.LogLevelWarn:
-			logLevel = slog.LevelWarn
-		case config.LogLevelError:
-			logLevel = slog.LevelError
-		}
-	}
-
-	// Create log file if configured
-	var logHandler slog.Handler
-	logPath, err := config.EnsureLogDir(cfg)
+	logCloser, err := setupLogging(cfg, debug)
 	if err != nil {
-		return fmt.Errorf("creating log directory: %w", err)
+		return nil, nil, nil, err
 	}
 
-	if logPath != "" {
-		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
-		if err != nil {
-			return fmt.Errorf("opening log file: %w", err)
-		}
-		defer logFile.Close()
+	slog.Info("VT-UOS starting", "version", Version, "build_time", BuildTime, "config_path", cfgPath)
 
-		logHandler = slog.NewJSONHandler(logFile, &slog.HandlerOptions{
-			Level: logLevel,
-		})
-	} else {
-		logHandler = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: logLevel,
-		})
-	}
-
-	logger := slog.New(logHandler)
-	slog.SetDefault(logger)
-
-	slog.Info("VT-UOS starting",
-		"version", Version,
-		"build_time", BuildTime,
-		"config_path", cfgPath,
-	)
-
-	// Get database path
 	dbPath, err := config.EnsureDataDir(cfg)
 	if err != nil {
-		return fmt.Errorf("ensuring data directory: %w", err)
+		logCloser()
+		return nil, nil, nil, fmt.Errorf("ensuring data directory: %w", err)
 	}
 
-	// Restore from a snapshot before opening, if requested. This is the safe
-	// way to reset an exhibit to a clean baseline.
 	if restorePath != "" {
 		if err := restoreDatabase(restorePath, dbPath); err != nil {
-			return fmt.Errorf("restoring database from snapshot: %w", err)
+			logCloser()
+			return nil, nil, nil, fmt.Errorf("restoring database from snapshot: %w", err)
 		}
 		slog.Info("vault database restored from snapshot", "from", restorePath, "to", dbPath)
 	}
 
-	// Get backup directory
 	backupDir, err := config.BackupDir(cfg)
 	if err != nil {
 		slog.Warn("failed to create backup directory", "error", err)
 		backupDir = ""
 	}
 
-	// Attempt database recovery if needed
 	if _, err := os.Stat(dbPath); err == nil {
 		report, err := database.AttemptRecovery(dbPath, backupDir)
 		if err != nil {
-			slog.Error("database recovery failed",
-				"path", dbPath,
-				"steps", len(report.Steps),
-			)
-			return fmt.Errorf("database recovery failed: %w", err)
+			logCloser()
+			return nil, nil, nil, fmt.Errorf("database recovery failed: %w", err)
 		}
-
 		switch report.Result {
 		case database.RecoveryFromBackup:
-			slog.Warn("database restored from backup",
-				"backup", report.BackupUsed,
-			)
+			slog.Warn("database restored from backup", "backup", report.BackupUsed)
 		case database.RecoverySuccess:
 			slog.Debug("database integrity verified")
 		}
 	}
 
-	// Open database
 	db, err := database.Open(dbPath, &cfg.Database, backupDir)
 	if err != nil {
-		return fmt.Errorf("opening database: %w", err)
+		logCloser()
+		return nil, nil, nil, fmt.Errorf("opening database: %w", err)
 	}
-	defer func() {
+
+	migrator, err := database.NewMigrator(db)
+	if err != nil {
+		db.Close()
+		logCloser()
+		return nil, nil, nil, fmt.Errorf("creating migrator: %w", err)
+	}
+	result, err := migrator.MigrateUp(ctx)
+	if err != nil {
+		db.Close()
+		logCloser()
+		return nil, nil, nil, fmt.Errorf("running migrations: %w", err)
+	}
+	if len(result.Applied) > 0 {
+		slog.Info("applied migrations", "count", len(result.Applied), "to_version", result.TargetVersion)
+	}
+
+	closeFn := func() {
 		slog.Info("closing database")
 		if err := db.Close(); err != nil {
 			slog.Error("error closing database", "error", err)
 		}
-	}()
+		logCloser()
+	}
+	return cfg, db, closeFn, nil
+}
 
-	// Run migrations
-	migrator, err := database.NewMigrator(db)
+// setupLogging configures slog and returns a closer for any opened log file.
+func setupLogging(cfg *config.Config, debug bool) (func(), error) {
+	level := logLevel(cfg, debug)
+	logPath, err := config.EnsureLogDir(cfg)
 	if err != nil {
-		return fmt.Errorf("creating migrator: %w", err)
+		return nil, fmt.Errorf("creating log directory: %w", err)
 	}
-
-	result, err := migrator.MigrateUp(ctx)
-	if err != nil {
-		return fmt.Errorf("running migrations: %w", err)
-	}
-
-	if len(result.Applied) > 0 {
-		slog.Info("applied migrations",
-			"count", len(result.Applied),
-			"to_version", result.TargetVersion,
-		)
-	}
-
-	// Exit early if migrate-only mode
-	if migrateOnly {
-		slog.Info("migrations complete, exiting")
-		return nil
-	}
-
-	// Generate seed data if requested
-	if seedData {
-		slog.Info("generating seed data", "vault", cfg.Vault.Number)
-
-		// Check if data already exists
-		var count int
-		if err := db.QueryRow("SELECT COUNT(*) FROM residents").Scan(&count); err == nil && count > 0 {
-			slog.Warn("database already contains residents, skipping seed generation", "count", count)
-			return nil
-		}
-
-		// Get seal date from config
-		sealDate, err := cfg.Simulation.StartDateTime()
+	if logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
 		if err != nil {
-			sealDate = time.Date(2077, 10, 23, 9, 47, 0, 0, time.UTC)
+			return nil, fmt.Errorf("opening log file: %w", err)
 		}
-
-		seedCfg := seed.Config{
-			VaultNumber:      cfg.Vault.Number,
-			SealDate:         sealDate,
-			TargetPopulation: cfg.Vault.DesignedCapacity,
-			FamilyHouseholds: 100,
-			SingleHouseholds: 80,
-			RandomSeed:       2077,
-		}
-
-		generator := seed.NewGenerator(db.DB, seedCfg)
-		if err := generator.Generate(ctx); err != nil {
-			return fmt.Errorf("generating seed data: %w", err)
-		}
-
-		slog.Info("seed data generation complete")
-		return nil
+		slog.SetDefault(slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{Level: level})))
+		return func() { f.Close() }, nil
 	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+	return func() {}, nil
+}
 
-	// Initialize vault clock
+// setupClientLogging keeps client logs off the terminal screen: it logs to the
+// configured file when present, and otherwise discards logs so the TUI is clean.
+func setupClientLogging(cfg *config.Config, debug bool) func() {
+	level := logLevel(cfg, debug)
+	if logPath, err := config.EnsureLogDir(cfg); err == nil && logPath != "" {
+		if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640); err == nil {
+			slog.SetDefault(slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{Level: level})))
+			return func() { f.Close() }
+		}
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level})))
+	return func() {}
+}
+
+func logLevel(cfg *config.Config, debug bool) slog.Level {
+	if debug {
+		return slog.LevelDebug
+	}
+	switch cfg.Logging.Level {
+	case config.LogLevelDebug:
+		return slog.LevelDebug
+	case config.LogLevelWarn:
+		return slog.LevelWarn
+	case config.LogLevelError:
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func newClock(cfg *config.Config) *util.VaultClock {
 	startTime, err := cfg.Simulation.StartDateTime()
 	if err != nil {
 		startTime = time.Now()
 	}
 	clock := util.NewVaultClock(startTime, cfg.Simulation.TimeScale)
-
 	if !cfg.Simulation.Enabled {
 		clock.Pause()
 	}
+	return clock
+}
 
-	// Start the simulation control core so the local console renders live,
-	// authoritative operational state.
-	engine := simulation.New(db, cfg, clock)
-	if err := engine.Start(ctx); err != nil {
-		slog.Warn("simulation control core failed to start", "error", err)
+func stopEngine(engine *simulation.Engine) {
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := engine.Stop(stopCtx); err != nil {
+		slog.Warn("error stopping simulation control core", "error", err)
 	}
-	defer func() {
-		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := engine.Stop(stopCtx); err != nil {
-			slog.Warn("error stopping simulation control core", "error", err)
-		}
-	}()
+}
 
-	// Set version info for TUI
-	tui.Version = Version
-	tui.BuildTime = BuildTime
+func runSeed(ctx context.Context, cfg *config.Config, db *database.DB) error {
+	slog.Info("generating seed data", "vault", cfg.Vault.Number)
 
-	// Run TUI
-	slog.Info("starting TUI",
-		"vault", cfg.Vault.Designation,
-		"simulation", cfg.Simulation.Enabled,
-	)
-
-	if err := tui.RunWithEngine(ctx, db, cfg, clock, engine); err != nil {
-		return fmt.Errorf("TUI error: %w", err)
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM residents").Scan(&count); err == nil && count > 0 {
+		slog.Warn("database already contains residents, skipping seed generation", "count", count)
+		return nil
 	}
 
-	slog.Info("VT-UOS shutdown complete")
+	sealDate, err := cfg.Simulation.StartDateTime()
+	if err != nil {
+		sealDate = time.Date(2077, 10, 23, 9, 47, 0, 0, time.UTC)
+	}
+
+	generator := seed.NewGenerator(db.DB, seed.Config{
+		VaultNumber:      cfg.Vault.Number,
+		SealDate:         sealDate,
+		TargetPopulation: cfg.Vault.DesignedCapacity,
+		FamilyHouseholds: 100,
+		SingleHouseholds: 80,
+		RandomSeed:       2077,
+	})
+	if err := generator.Generate(ctx); err != nil {
+		return fmt.Errorf("generating seed data: %w", err)
+	}
+	slog.Info("seed data generation complete")
 	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // restoreDatabase copies a snapshot file over the live database path, removing

--- a/cmd/vtuos/main.go
+++ b/cmd/vtuos/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -17,6 +18,7 @@ import (
 	"github.com/vtuos/vtuos/internal/config"
 	"github.com/vtuos/vtuos/internal/database"
 	"github.com/vtuos/vtuos/internal/database/seed"
+	"github.com/vtuos/vtuos/internal/simulation"
 	"github.com/vtuos/vtuos/internal/tui"
 	"github.com/vtuos/vtuos/internal/util"
 )
@@ -35,6 +37,7 @@ func main() {
 		seedData    = flag.Bool("seed", false, "Generate seed data")
 		showVersion = flag.Bool("version", false, "Show version and exit")
 		debugMode   = flag.Bool("debug", false, "Enable debug logging")
+		restorePath = flag.String("restore", "", "Restore the vault database from a snapshot file before starting")
 	)
 	flag.Parse()
 
@@ -65,13 +68,13 @@ func main() {
 	}()
 
 	// Run the application
-	if err := run(ctx, *configPath, *migrateOnly, *seedData, *debugMode); err != nil {
+	if err := run(ctx, *configPath, *migrateOnly, *seedData, *debugMode, *restorePath); err != nil {
 		slog.Error("application error", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, configPath string, migrateOnly, seedData, debugMode bool) error {
+func run(ctx context.Context, configPath string, migrateOnly, seedData, debugMode bool, restorePath string) error {
 	// Load configuration
 	cfg, cfgPath, err := config.Load(configPath, true)
 	if err != nil {
@@ -129,6 +132,15 @@ func run(ctx context.Context, configPath string, migrateOnly, seedData, debugMod
 	dbPath, err := config.EnsureDataDir(cfg)
 	if err != nil {
 		return fmt.Errorf("ensuring data directory: %w", err)
+	}
+
+	// Restore from a snapshot before opening, if requested. This is the safe
+	// way to reset an exhibit to a clean baseline.
+	if restorePath != "" {
+		if err := restoreDatabase(restorePath, dbPath); err != nil {
+			return fmt.Errorf("restoring database from snapshot: %w", err)
+		}
+		slog.Info("vault database restored from snapshot", "from", restorePath, "to", dbPath)
 	}
 
 	// Get backup directory
@@ -241,6 +253,20 @@ func run(ctx context.Context, configPath string, migrateOnly, seedData, debugMod
 		clock.Pause()
 	}
 
+	// Start the simulation control core so the local console renders live,
+	// authoritative operational state.
+	engine := simulation.New(db, cfg, clock)
+	if err := engine.Start(ctx); err != nil {
+		slog.Warn("simulation control core failed to start", "error", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := engine.Stop(stopCtx); err != nil {
+			slog.Warn("error stopping simulation control core", "error", err)
+		}
+	}()
+
 	// Set version info for TUI
 	tui.Version = Version
 	tui.BuildTime = BuildTime
@@ -251,10 +277,35 @@ func run(ctx context.Context, configPath string, migrateOnly, seedData, debugMod
 		"simulation", cfg.Simulation.Enabled,
 	)
 
-	if err := tui.Run(ctx, db, cfg, clock); err != nil {
+	if err := tui.RunWithEngine(ctx, db, cfg, clock, engine); err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}
 
 	slog.Info("VT-UOS shutdown complete")
 	return nil
+}
+
+// restoreDatabase copies a snapshot file over the live database path, removing
+// any stale WAL/SHM sidecar files so the restored database opens cleanly.
+func restoreDatabase(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening snapshot: %w", err)
+	}
+	defer in.Close()
+
+	for _, sidecar := range []string{dst + "-wal", dst + "-shm"} {
+		_ = os.Remove(sidecar)
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
+	if err != nil {
+		return fmt.Errorf("opening destination: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copying snapshot: %w", err)
+	}
+	return out.Sync()
 }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,168 @@
+# Deployment: Local, Master Server, and Client Terminals
+
+VT-UOS ships as a **single static binary** with three run modes. The server and
+client modes use only the Go standard library for transport (`net/http`,
+`html/template`, `go:embed`) — no web framework — so the single-binary,
+no-CGO, offline-first constraints hold.
+
+```
+vtuos                 Local operator console (TUI + in-process control core)
+vtuos serve           Master server (authoritative core + JSON/SSE API + web console)
+vtuos connect <addr>  Client display/operator terminal driven by a master
+```
+
+## Interactive-exhibit topology
+
+```
+                        ┌──────────────────────────────┐
+                        │        vtuos serve           │
+                        │  authoritative control core  │
+                        │  JSON API · SSE · web console │
+                        └───────────────┬──────────────┘
+                                        │ HTTP / SSE
+        ┌───────────────────┬───────────┴───────────┬───────────────────┐
+        ▼                   ▼                       ▼                   ▼
+  vtuos connect       vtuos connect           vtuos connect       Web browser
+  (atrium display)    (corridor display)      (operator podium)   (overseer console)
+```
+
+One master runs the simulation; any number of client terminals render the live
+state it streams and report their telemetry back. An operator drives everything
+— the simulation and the terminals — from the embedded web console or the API.
+
+## Master server (`vtuos serve`)
+
+```bash
+vtuos serve                              # uses [server] config
+vtuos serve --listen :8080 --token SECRET
+vtuos serve --config testdata/vault-exhibit.toml
+```
+
+`[server]` configuration:
+
+```toml
+[server]
+listen = ":8080"
+admin_token = "change-me-overseer-token"  # required for control/admin endpoints
+enable_web = true                           # serve the web console
+heartbeat_seconds = 5                       # client heartbeat cadence
+client_timeout_seconds = 20                 # mark a client offline after silence
+```
+
+> If `admin_token` is empty, control and client-management endpoints are
+> **unauthenticated** and a warning is logged at startup. Always set a token for
+> any networked deployment.
+
+### Web administration console
+
+With `enable_web = true`, browse to `http://<master>:8080/`. The green-phosphor
+console provides:
+
+- **Overview** — live population, power, systems, resource runway, and alerts (via SSE).
+- **Simulation** — pause/resume, time-scale selector, single-step (1h/1d/1w),
+  snapshot. Enter the operator token once (stored locally) to authorise actions.
+- **Systems** — live facility table with efficiency.
+- **Terminals** — connected clients with state/telemetry and remote-operation buttons.
+- **Event log** — the operational event feed.
+
+### HTTP API
+
+Read endpoints are open (so displays can poll freely); control and
+client-management endpoints require the operator token via
+`Authorization: Bearer <token>` or `X-Admin-Token: <token>`.
+
+| Method & path                          | Auth      | Purpose                              |
+| -------------------------------------- | --------- | ------------------------------------ |
+| `GET /healthz`                         | open      | Liveness                             |
+| `GET /api/v1/health`                   | open      | Machine-readable health summary      |
+| `GET /api/v1/state`                    | open      | Full operational snapshot            |
+| `GET /api/v1/status`                   | open      | Sim status summary                   |
+| `GET /api/v1/events?limit=N`           | open      | Operational event log                |
+| `GET /api/v1/alerts`                   | open      | Active alerts                        |
+| `GET /api/v1/systems` / `population` / `resources` | open | Section snapshots          |
+| `GET /api/v1/stream`                   | open      | Live state via Server-Sent Events    |
+| `POST /api/v1/sim/pause` / `resume`    | operator  | Control progression                  |
+| `POST /api/v1/sim/scale`               | operator  | `{"time_scale": 1440}`               |
+| `POST /api/v1/sim/step`                | operator  | `{"hours": 24}`                      |
+| `POST /api/v1/sim/snapshot`            | operator  | Snapshot the database                |
+| `POST /api/v1/sim/ack`                 | operator  | `{"code": "POWER_DEFICIT"}`          |
+| `POST /api/v1/clients/register`        | open      | Terminal registration                |
+| `POST /api/v1/clients/{id}/heartbeat`  | client    | Telemetry + receive remote ops       |
+| `POST /api/v1/clients/{id}/result`     | client    | Report remote-op outcome             |
+| `GET  /api/v1/clients`                 | operator  | List connected terminals             |
+| `POST /api/v1/clients/{id}/command`    | operator  | Queue a remote operation             |
+
+Example:
+
+```bash
+curl -s localhost:8080/api/v1/state | jq .population
+curl -s -X POST localhost:8080/api/v1/sim/step \
+     -H 'X-Admin-Token: SECRET' -d '{"hours":24}'
+```
+
+## Client terminal (`vtuos connect`)
+
+```bash
+vtuos connect 127.0.0.1:8080
+vtuos connect --name "Atrium Display" --kind display master.local:8080
+vtuos connect --kind operator 10.0.0.5:8080
+```
+
+A terminal:
+
+1. **Registers** with the master and receives an id + token.
+2. **Streams** live state over SSE and renders it (read-only dashboard with
+   Systems / Resources / Events / Population pages).
+3. **Reports telemetry** (current view, kiosk state, uptime, dimensions) on each
+   heartbeat — the "report back to the server" channel.
+4. **Executes remote operations** the master returns on a heartbeat.
+
+`[client]` configuration provides defaults:
+
+```toml
+[client]
+name = "Atrium Display"
+kind = "DISPLAY"   # DISPLAY (unattended) or OPERATOR
+```
+
+### Remote operations
+
+Issued from the web console (Terminals tab) or `POST /api/v1/clients/{id}/command`:
+
+| Command       | Args                | Effect on the terminal                    |
+| ------------- | ------------------- | ----------------------------------------- |
+| `SWITCH_VIEW` | `view`              | Change the displayed page                 |
+| `SET_KIOSK`   | `enabled` (true/false) | Lock/unlock local input                 |
+| `MESSAGE`     | `text`              | Show an overseer message banner           |
+| `IDENTIFY`    | —                   | Flash an identifying banner               |
+| `REFRESH`     | —                   | Force a state refresh                     |
+| `REBOOT`      | —                   | Reconnect the terminal                    |
+| `SHUTDOWN`    | —                   | Gracefully terminate the terminal         |
+
+## Exhibit kiosk presentation
+
+The `[exhibit]` section adds unattended presentation, useful for displays:
+
+```toml
+[exhibit]
+boot_sequence = true          # RobCo-style startup
+attract_mode = true           # auto-rotate views when idle
+attract_idle_seconds = 90
+rotate_seconds = 12
+kiosk = true                  # disable quit so visitors can't close the display
+```
+
+These are **off by default** so the console stays a utilitarian operator tool;
+`testdata/vault-exhibit.toml` is a ready-made exhibit profile.
+
+## Resetting an exhibit
+
+Snapshot before a demonstration, then restore afterward:
+
+```bash
+# Snapshot (operator console, web Simulation tab, or API)
+curl -X POST localhost:8080/api/v1/sim/snapshot -H 'X-Admin-Token: SECRET'
+
+# Reset to a clean baseline (stop the process first, then):
+vtuos serve --restore ~/.local/share/vtuos/backups/vault-20771023-094700.db
+```

--- a/docs/SIMULATION.md
+++ b/docs/SIMULATION.md
@@ -1,0 +1,120 @@
+# Simulation Control Core
+
+The simulation control core (`internal/simulation`) is the authoritative engine
+that advances vault time and drives realistic operations against the persistent
+database. It is **operational software, not a game**: every interval it processes
+is deterministic given its seed, mutates real domain state through the service
+layer, records occurrences to the persistent event and audit logs, and publishes
+an operational snapshot to subscribers.
+
+## Design goals
+
+- **Authoritative** — one engine owns vault progression; the TUI, web console,
+  and client terminals all read the same `protocol.VaultState` it produces.
+- **Persistent** — consumption, production, degradation, maintenance, incidents,
+  and demographics are written to the database through the existing services and
+  mirrored to `simulation_events` and the immutable `audit_log`.
+- **Deterministic** — a stable seed derived from the vault number and seal date
+  drives a single `math/rand` source, so identical configurations replay
+  identically (supporting the project's reproducible-build constraint).
+- **Power-loss resilient** — operational position (vault time, birth/death
+  counters, tick count) is checkpointed to `vault_metadata` so a restart resumes
+  where it left off.
+
+## Processing model
+
+The engine wakes on a fixed real-time cadence and advances simulated time to
+match the wall-clock-scaled vault time. Whole simulated **hours** are advanced
+one at a time; the heavy operational accounting runs once per simulated **day**,
+which bounds database writes regardless of time scale.
+
+```
+Each simulated day (processDay):
+  1. Resource consumption   — water (L) and food (kcal→kg) drawn FIFO from stock,
+                              plus routine medical/consumable draw; shortfalls
+                              are reported as critical events.
+  2. Resource production     — producible items, scaled by the efficiency of the
+                              governing facility (hydroponics→food, treatment→water).
+  3. Expiration              — perishables past shelf life written off as spoilage.
+  4. Facility degradation    — per-day efficiency wear (accelerated when overdue),
+                              status transitions (operational→degraded→failed),
+                              runtime accrual.
+  5. Maintenance sweep       — overdue/failed systems serviced with some daily
+                              probability, restoring condition and consuming parts.
+  6. Operational incidents   — one weighted unplanned incident may occur (see below).
+  7. Demographics            — low-probability births/deaths via the population
+                              service (registries, lineage and counts stay consistent).
+  8. Persist                 — checkpoint operational position; recompute and
+                              broadcast the snapshot.
+```
+
+A single automatic wake processes at most one simulated week (`maxHoursPerWake`)
+as runaway protection; an explicit operator **step** drains the full requested
+span in capped chunks.
+
+## Operational incidents
+
+When `auto_events` is enabled, each day has a configurable probability (by
+`event_frequency`) of one unplanned incident. The incident table is weighted by
+current conditions — failing systems make equipment faults more likely, scarce
+resources raise security incidents, crowding raises conflict. Incidents are
+framed and recorded as real operational events:
+
+| Incident          | Effect (persisted)                                              |
+| ----------------- | --------------------------------------------------------------- |
+| Equipment fault   | Sudden efficiency loss on a random operational system           |
+| Contamination     | A stock lot moved to `QUARANTINE` pending assay                 |
+| Illness / outbreak| Contagious `medical_conditions` record; severe cases quarantined|
+| Security incident | A `security_incidents` record (altercation, theft, …)           |
+| Cache recovered   | Recovered stock added to inventory (a positive incident)        |
+
+Every incident is written to `simulation_events` and `audit_log` with the
+`SIMULATION` actor, so the governance audit trail reflects them.
+
+## Alerts
+
+Alerts are derived from the current snapshot each cycle (not ad-hoc), so they
+always reflect present conditions: power deficit/low reserve, failed/degraded/
+overdue systems, critical/low resource runway, sub-viable or over-capacity
+population, and medical quarantine. Acknowledgement state is preserved across
+recomputes by alert code.
+
+## Control API
+
+```go
+engine := simulation.New(db, cfg, clock)
+engine.Start(ctx)                 // restore continuity, ensure core systems, begin
+engine.Pause(); engine.Resume()
+engine.SetTimeScale(1440)         // vault-seconds per real-second
+engine.Step(ctx, 24)             // advance & process N hours (operator action)
+state := engine.Snapshot()        // latest protocol.VaultState (copy)
+alerts := engine.Alerts()
+events := engine.Events(50)
+engine.AcknowledgeAlert(code)
+path, _ := engine.CreateSnapshot(ctx) // VACUUM INTO backup
+id, ch := engine.Subscribe()      // live snapshots (SSE / TUI)
+engine.Stop(ctx)                  // checkpoint and halt
+```
+
+## Configuration
+
+```toml
+[simulation]
+enabled = true
+time_scale = 1440.0          # 1 real minute ≈ 1 vault day
+auto_events = true
+event_frequency = "normal"   # minimal | reduced | normal | increased | chaotic
+start_date = "2077-10-23T09:47:00Z"
+
+[simulation.consumption]
+calorie_variance = 0.1       # ±10% daily variance
+water_variance = 0.1
+efficiency_decay_rate = 0.001 # base facility wear per day
+```
+
+## Snapshot & reset
+
+`engine.CreateSnapshot` captures a consistent copy of the whole database to the
+backup directory (`VACUUM INTO`). To reset an exhibit to a clean baseline, stop
+the process and relaunch with `vtuos --restore <snapshot.db>` (or `serve
+--restore`), which safely swaps the database file before reopening.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -28,6 +28,7 @@ type model struct {
 	bannerUntil time.Time
 	kiosk       bool
 	frames      uint64
+	errors      uint64
 	quitting    bool
 
 	stateCh chan protocol.VaultState
@@ -123,6 +124,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case hbResultMsg:
 		if msg.err != nil {
 			m.connected = false
+			m.errors++
 			return m, nil
 		}
 		return m.applyCommands(msg.commands)
@@ -173,6 +175,7 @@ func (m *model) doHeartbeat() tea.Cmd {
 		CurrentView:    m.page,
 		KioskMode:      m.kiosk,
 		FramesRendered: m.frames,
+		Errors:         m.errors,
 		WidthCols:      m.width,
 		HeightRows:     m.height,
 	}
@@ -212,6 +215,7 @@ func (m *model) applyCommands(cmds []protocol.Command) (tea.Model, tea.Cmd) {
 			effects = append(effects, tea.Quit)
 		default:
 			ok, message = false, "unsupported command"
+			m.errors++
 		}
 		effects = append(effects, m.reportResult(c.ID, ok, message))
 	}
@@ -236,8 +240,12 @@ func Run(ctx context.Context, conn *Conn, cfg *config.Config) error {
 	theme := tui.NewTheme(cfg.Display.ColorScheme)
 	m := newModel(conn, theme, rr.VaultDesignation)
 
-	// Stream live state in the background, reconnecting on failure.
+	// Stream live state in the background, reconnecting on failure. Closing the
+	// channels when this goroutine exits unblocks the model's listen commands so
+	// the Bubble Tea loop can drain cleanly.
 	go func() {
+		defer close(m.stateCh)
+		defer close(m.connCh)
 		for ctx.Err() == nil {
 			if err := conn.StreamStates(ctx, m.stateCh); err != nil {
 				select {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,280 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/vtuos/vtuos/internal/config"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/tui"
+)
+
+// model is the Bubble Tea model for a client display terminal.
+type model struct {
+	conn  *Conn
+	theme *tui.Theme
+	start time.Time
+
+	width, height int
+	state         protocol.VaultState
+	haveState     bool
+	connected     bool
+	vault         string
+
+	page        string
+	banner      string
+	bannerUntil time.Time
+	kiosk       bool
+	frames      uint64
+	quitting    bool
+
+	stateCh chan protocol.VaultState
+	connCh  chan bool
+}
+
+type stateMsg protocol.VaultState
+type connMsg bool
+type hbTickMsg struct{}
+type hbResultMsg struct {
+	commands []protocol.Command
+	err      error
+}
+type secondMsg struct{}
+
+func newModel(conn *Conn, theme *tui.Theme, vault string) *model {
+	return &model{
+		conn:    conn,
+		theme:   theme,
+		start:   time.Now(),
+		vault:   vault,
+		page:    "dashboard",
+		stateCh: make(chan protocol.VaultState, 8),
+		connCh:  make(chan bool, 8),
+	}
+}
+
+func (m *model) Init() tea.Cmd {
+	return tea.Batch(
+		tea.EnterAltScreen,
+		m.listenState(),
+		m.listenConn(),
+		hbTickCmd(m.conn.HeartbeatInterval()),
+		secondCmd(),
+	)
+}
+
+func (m *model) listenState() tea.Cmd {
+	return func() tea.Msg {
+		st, ok := <-m.stateCh
+		if !ok {
+			return nil
+		}
+		return stateMsg(st)
+	}
+}
+
+func (m *model) listenConn() tea.Cmd {
+	return func() tea.Msg {
+		v, ok := <-m.connCh
+		if !ok {
+			return nil
+		}
+		return connMsg(v)
+	}
+}
+
+func hbTickCmd(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return hbTickMsg{} })
+}
+
+func secondCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg { return secondMsg{} })
+}
+
+func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case stateMsg:
+		m.state = protocol.VaultState(msg)
+		m.haveState = true
+		m.connected = true
+		if m.state.VaultDesignation != "" {
+			m.vault = m.state.VaultDesignation
+		}
+		return m, m.listenState()
+
+	case connMsg:
+		if !bool(msg) {
+			m.connected = false
+		}
+		return m, m.listenConn()
+
+	case hbTickMsg:
+		return m, tea.Batch(m.doHeartbeat(), hbTickCmd(m.conn.HeartbeatInterval()))
+
+	case hbResultMsg:
+		if msg.err != nil {
+			m.connected = false
+			return m, nil
+		}
+		return m.applyCommands(msg.commands)
+
+	case secondMsg:
+		m.frames++
+		if m.banner != "" && time.Now().After(m.bannerUntil) {
+			m.banner = ""
+		}
+		if m.quitting {
+			return m, tea.Quit
+		}
+		return m, secondCmd()
+	}
+	return m, nil
+}
+
+func (m *model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		m.quitting = true
+		return m, tea.Quit
+	}
+	if m.kiosk {
+		return m, nil // locked down for unattended display
+	}
+	switch msg.String() {
+	case "q", "esc":
+		m.quitting = true
+		return m, tea.Quit
+	case "1":
+		m.page = "dashboard"
+	case "2":
+		m.page = "systems"
+	case "3":
+		m.page = "resources"
+	case "4":
+		m.page = "events"
+	case "5":
+		m.page = "population"
+	}
+	return m, nil
+}
+
+// doHeartbeat snapshots telemetry on the main goroutine and reports it.
+func (m *model) doHeartbeat() tea.Cmd {
+	tel := protocol.Telemetry{
+		UptimeSeconds:  int64(time.Since(m.start).Seconds()),
+		CurrentView:    m.page,
+		KioskMode:      m.kiosk,
+		FramesRendered: m.frames,
+		WidthCols:      m.width,
+		HeightRows:     m.height,
+	}
+	conn := m.conn
+	return func() tea.Msg {
+		cmds, err := conn.Heartbeat(context.Background(), tel)
+		return hbResultMsg{commands: cmds, err: err}
+	}
+}
+
+// applyCommands executes remote operations and acknowledges them to the master.
+func (m *model) applyCommands(cmds []protocol.Command) (tea.Model, tea.Cmd) {
+	m.connected = true
+	var effects []tea.Cmd
+	for _, c := range cmds {
+		ok, message := true, "applied"
+		switch c.Type {
+		case protocol.CmdSwitchView:
+			if v := c.Args["view"]; v != "" {
+				m.page = v
+			}
+		case protocol.CmdSetKiosk:
+			m.kiosk = c.Args["enabled"] == "true"
+		case protocol.CmdMessage:
+			m.banner = c.Args["text"]
+			m.bannerUntil = time.Now().Add(10 * time.Second)
+		case protocol.CmdIdentify:
+			m.banner = "◢◤  THIS TERMINAL — " + m.conn.ID()[:8] + "  ◥◣"
+			m.bannerUntil = time.Now().Add(6 * time.Second)
+		case protocol.CmdRefresh:
+			message = "refreshed"
+		case protocol.CmdReboot:
+			m.banner = "RECONNECTING TERMINAL…"
+			m.bannerUntil = time.Now().Add(5 * time.Second)
+		case protocol.CmdShutdown:
+			m.quitting = true
+			effects = append(effects, tea.Quit)
+		default:
+			ok, message = false, "unsupported command"
+		}
+		effects = append(effects, m.reportResult(c.ID, ok, message))
+	}
+	return m, tea.Batch(effects...)
+}
+
+func (m *model) reportResult(cmdID string, ok bool, message string) tea.Cmd {
+	conn := m.conn
+	res := protocol.CommandResult{CommandID: cmdID, OK: ok, Message: message, Completed: time.Now().UTC()}
+	return func() tea.Msg {
+		_ = conn.ReportResult(context.Background(), res)
+		return nil
+	}
+}
+
+// Run registers with the master and runs the client display terminal.
+func Run(ctx context.Context, conn *Conn, cfg *config.Config) error {
+	rr, err := registerWithRetry(ctx, conn)
+	if err != nil {
+		return err
+	}
+	theme := tui.NewTheme(cfg.Display.ColorScheme)
+	m := newModel(conn, theme, rr.VaultDesignation)
+
+	// Stream live state in the background, reconnecting on failure.
+	go func() {
+		for ctx.Err() == nil {
+			if err := conn.StreamStates(ctx, m.stateCh); err != nil {
+				select {
+				case m.connCh <- false:
+				default:
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}()
+
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	go func() {
+		<-ctx.Done()
+		p.Quit()
+	}()
+	_, err = p.Run()
+	return err
+}
+
+func registerWithRetry(ctx context.Context, conn *Conn) (protocol.RegisterResponse, error) {
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		rr, err := conn.Register(ctx)
+		if err == nil {
+			return rr, nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return protocol.RegisterResponse{}, ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * time.Second):
+		}
+	}
+	return protocol.RegisterResponse{}, fmt.Errorf("could not reach master server: %w", lastErr)
+}

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -1,0 +1,168 @@
+// Package client implements the VT-UOS client terminal (vtuos connect): a
+// managed display/operator node that registers with a master server, renders
+// the live operational state it streams, reports telemetry back on a heartbeat,
+// and executes remote operations the master issues.
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// Conn is the HTTP transport between a client terminal and the master server.
+type Conn struct {
+	base    string
+	hc      *http.Client
+	name    string
+	kind    protocol.ClientKind
+	version string
+
+	id        string
+	token     string
+	heartbeat int
+}
+
+// NewConn creates a transport to the master at addr (host:port or full URL).
+func NewConn(addr, name string, kind protocol.ClientKind, version string) *Conn {
+	base := strings.TrimRight(addr, "/")
+	if !strings.HasPrefix(base, "http://") && !strings.HasPrefix(base, "https://") {
+		base = "http://" + base
+	}
+	return &Conn{
+		base:      base,
+		hc:        &http.Client{Timeout: 15 * time.Second},
+		name:      name,
+		kind:      kind,
+		version:   version,
+		heartbeat: 5,
+	}
+}
+
+// HeartbeatInterval returns the cadence the master requested.
+func (c *Conn) HeartbeatInterval() time.Duration {
+	if c.heartbeat <= 0 {
+		return 5 * time.Second
+	}
+	return time.Duration(c.heartbeat) * time.Second
+}
+
+// VaultName returns the registered vault designation (after Register).
+func (c *Conn) ID() string { return c.id }
+
+// Register admits this terminal to the master and stores its credentials.
+func (c *Conn) Register(ctx context.Context) (protocol.RegisterResponse, error) {
+	body, _ := json.Marshal(protocol.RegisterRequest{
+		Protocol: protocol.Version,
+		Name:     c.name,
+		Kind:     c.kind,
+		Version:  c.version,
+	})
+	req, _ := http.NewRequestWithContext(ctx, "POST", c.base+"/api/v1/clients/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return protocol.RegisterResponse{}, fmt.Errorf("registering: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return protocol.RegisterResponse{}, fmt.Errorf("register rejected: %s", resp.Status)
+	}
+	var rr protocol.RegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rr); err != nil {
+		return protocol.RegisterResponse{}, fmt.Errorf("decoding registration: %w", err)
+	}
+	c.id = rr.ClientID
+	c.token = rr.Token
+	if rr.HeartbeatSeconds > 0 {
+		c.heartbeat = rr.HeartbeatSeconds
+	}
+	return rr, nil
+}
+
+// StreamStates opens the master's SSE stream and delivers each state frame to
+// out until the context is cancelled or the stream fails.
+func (c *Conn) StreamStates(ctx context.Context, out chan<- protocol.VaultState) error {
+	req, _ := http.NewRequestWithContext(ctx, "GET", c.base+"/api/v1/stream", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("opening stream: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("stream rejected: %s", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	var data strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			// End of an event: flush any accumulated data as a state frame.
+			if data.Len() > 0 {
+				var st protocol.VaultState
+				if err := json.Unmarshal([]byte(data.String()), &st); err == nil {
+					select {
+					case out <- st:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+				data.Reset()
+			}
+		case strings.HasPrefix(line, "data:"):
+			data.WriteString(strings.TrimSpace(line[5:]))
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	return scanner.Err()
+}
+
+// Heartbeat reports telemetry and returns any pending remote operations.
+func (c *Conn) Heartbeat(ctx context.Context, tel protocol.Telemetry) ([]protocol.Command, error) {
+	body, _ := json.Marshal(tel)
+	url := fmt.Sprintf("%s/api/v1/clients/%s/heartbeat", c.base, c.id)
+	req, _ := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Client-Token", c.token)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("heartbeat rejected: %s", resp.Status)
+	}
+	var hr protocol.HeartbeatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&hr); err != nil {
+		return nil, err
+	}
+	return hr.Commands, nil
+}
+
+// ReportResult reports the outcome of a remote operation to the master.
+func (c *Conn) ReportResult(ctx context.Context, res protocol.CommandResult) error {
+	body, _ := json.Marshal(res)
+	url := fmt.Sprintf("%s/api/v1/clients/%s/result", c.base, c.id)
+	req, _ := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Client-Token", c.token)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/internal/client/view.go
+++ b/internal/client/view.go
@@ -1,0 +1,284 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+func (m *model) View() string {
+	if m.width == 0 {
+		return "Connecting to master server…"
+	}
+	if m.quitting {
+		return m.theme.Title.Render("Terminal disconnecting…")
+	}
+
+	var b strings.Builder
+	b.WriteString(m.renderHeader())
+	b.WriteString("\n")
+	b.WriteString(m.theme.DrawDoubleLine(m.width))
+	b.WriteString("\n")
+
+	if m.banner != "" {
+		banner := lipgloss.NewStyle().Width(m.width).Align(lipgloss.Center).Render(m.theme.Accent.Bold(true).Render(m.banner))
+		b.WriteString(banner)
+		b.WriteString("\n\n")
+	}
+
+	if !m.haveState {
+		b.WriteString(m.theme.Muted.Render("  Awaiting operational state from master…"))
+	} else {
+		switch m.page {
+		case "systems":
+			b.WriteString(m.renderSystems())
+		case "resources":
+			b.WriteString(m.renderResources())
+		case "events":
+			b.WriteString(m.renderEvents())
+		case "population":
+			b.WriteString(m.renderPopulation())
+		default:
+			b.WriteString(m.renderDashboard())
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.renderFooter())
+	return b.String()
+}
+
+func (m *model) renderHeader() string {
+	conn := m.theme.Error.Render("● OFFLINE")
+	if m.connected {
+		conn = m.theme.Success.Render("● LIVE")
+	}
+	st := m.statusBadge()
+	left := m.theme.Header.Render("VT-UOS DISPLAY · " + m.vault)
+	right := fmt.Sprintf("%s  %s  %s", st, m.theme.Value.Render(vaultTime(m.state)), conn)
+	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+func (m *model) statusBadge() string {
+	switch m.state.Status {
+	case protocol.SimRunning:
+		return m.theme.Success.Render("RUNNING")
+	case protocol.SimPaused:
+		return m.theme.Warning.Render("PAUSED")
+	default:
+		return m.theme.Muted.Render("STOPPED")
+	}
+}
+
+func vaultTime(st protocol.VaultState) string {
+	return st.VaultTime.Format("2006-01-02 15:04")
+}
+
+func (m *model) renderDashboard() string {
+	pop := m.panel("POPULATION", m.popBody(), m.colWidth(3))
+	pwr := m.panel("POWER", m.powerBody(), m.colWidth(3))
+	sys := m.panel("SYSTEMS", m.sysSummaryBody(), m.colWidth(3))
+	top := lipgloss.JoinHorizontal(lipgloss.Top, pop, " ", pwr, " ", sys)
+
+	res := m.panel("RESOURCE RUNWAY", m.resourceBody(), m.colWidth(2))
+	alr := m.panel("ACTIVE ALERTS", m.alertsBody(), m.colWidth(2))
+	mid := lipgloss.JoinHorizontal(lipgloss.Top, res, " ", alr)
+
+	ev := m.panel("OPERATIONAL EVENT LOG", m.eventsBody(6), m.width-4)
+
+	return top + "\n" + mid + "\n" + ev
+}
+
+func (m *model) colWidth(cols int) int {
+	w := (m.width - (cols+1)*1) / cols
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+func (m *model) panel(title, body string, width int) string {
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(m.theme.SecondaryColor).
+		Width(width-2).
+		Padding(0, 1)
+	header := m.theme.Accent.Bold(true).Render(title) + "\n"
+	return style.Render(header + body)
+}
+
+func (m *model) popBody() string {
+	p := m.state.Population
+	return fmt.Sprintf("Active:  %s / %s\nLoad:    %s\nBirths:  %s   Deaths: %s\nAvg age: %s",
+		m.theme.Value.Render(itoa(p.Active)), m.theme.Muted.Render(itoa(p.Capacity)),
+		m.theme.Value.Render(fmt.Sprintf("%.0f%%", p.LoadPct)),
+		m.theme.Success.Render(itoa(p.Births)), m.theme.Error.Render(itoa(p.Deaths)),
+		m.theme.Value.Render(fmt.Sprintf("%.1f", p.AverageAge)))
+}
+
+func (m *model) powerBody() string {
+	pw := m.state.Power
+	balStyle := m.theme.Success
+	if pw.BalanceKW < 0 {
+		balStyle = m.theme.Error
+	} else if pw.ReservePct < 10 {
+		balStyle = m.theme.Warning
+	}
+	return fmt.Sprintf("Gen:     %s kW\nLoad:    %s kW\nBalance: %s\nReserve: %s",
+		m.theme.Value.Render(fmt.Sprintf("%.0f", pw.GenerationKW)),
+		m.theme.Value.Render(fmt.Sprintf("%.0f", pw.ConsumptionKW)),
+		balStyle.Render(fmt.Sprintf("%+.0f kW", pw.BalanceKW)),
+		balStyle.Render(fmt.Sprintf("%.0f%%", pw.ReservePct)))
+}
+
+func (m *model) sysSummaryBody() string {
+	s := m.state.Systems
+	return fmt.Sprintf("Operational: %s\nDegraded:    %s\nFailed:      %s\nAvg eff:     %s\nOverdue PM:  %s",
+		m.theme.Success.Render(itoa(s.Operational)),
+		m.theme.Warning.Render(itoa(s.Degraded)),
+		m.theme.Error.Render(itoa(s.Failed)),
+		m.theme.Value.Render(fmt.Sprintf("%.0f%%", s.AvgEfficiency)),
+		m.theme.Warning.Render(itoa(s.OverdueMaint)))
+}
+
+func (m *model) resourceBody() string {
+	var b strings.Builder
+	any := false
+	for _, r := range m.state.Resources {
+		if r.DailyUse <= 0 {
+			continue
+		}
+		any = true
+		runway := "∞"
+		if r.RunwayDays >= 0 {
+			runway = itoa(r.RunwayDays) + "d"
+		}
+		b.WriteString(fmt.Sprintf("%-10s %s\n", r.Label, m.statusStyle(r.Status).Render(runway+" ("+r.Status+")")))
+	}
+	if !any {
+		return m.theme.Muted.Render("No metered consumption yet.")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (m *model) alertsBody() string {
+	if len(m.state.Alerts) == 0 {
+		return m.theme.Success.Render("✓ All systems nominal")
+	}
+	var b strings.Builder
+	for i, a := range m.state.Alerts {
+		if i >= 4 {
+			break
+		}
+		style := m.theme.Warning
+		if a.Level == protocol.AlertCritical {
+			style = m.theme.Error
+		}
+		b.WriteString(style.Render("["+string(a.Level)+"] ") + a.Message + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (m *model) eventsBody(n int) string {
+	if len(m.state.RecentEvents) == 0 {
+		return m.theme.Muted.Render("No events recorded.")
+	}
+	var b strings.Builder
+	for i, e := range m.state.RecentEvents {
+		if i >= n {
+			break
+		}
+		ts := e.VaultTime.Format("01-02 15:04")
+		line := fmt.Sprintf("%s  %-10s %s", m.theme.Muted.Render(ts), e.Category, e.Summary)
+		if e.Severity == protocol.AlertCritical {
+			line = m.theme.Error.Render(line)
+		} else if e.Severity == protocol.AlertWarning {
+			line = m.theme.Warning.Render(line)
+		}
+		b.WriteString(line + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (m *model) renderSystems() string {
+	var b strings.Builder
+	b.WriteString(m.theme.Title.Render("FACILITY SYSTEMS"))
+	b.WriteString("\n\n")
+	for _, s := range m.state.SystemList {
+		style := m.theme.Success
+		if s.Efficiency < 50 {
+			style = m.theme.Error
+		} else if s.Efficiency < 80 {
+			style = m.theme.Warning
+		}
+		b.WriteString(fmt.Sprintf("  %-14s %-22s %s %s\n",
+			s.Code, s.Name, m.theme.ProgressBar(s.Efficiency, 100, 16),
+			style.Render(fmt.Sprintf("%3.0f%% %s", s.Efficiency, s.Status))))
+	}
+	return b.String()
+}
+
+func (m *model) renderResources() string {
+	var b strings.Builder
+	b.WriteString(m.theme.Title.Render("RESOURCE RUNWAY"))
+	b.WriteString("\n\n")
+	for _, r := range m.state.Resources {
+		runway := "∞"
+		if r.RunwayDays >= 0 {
+			runway = itoa(r.RunwayDays) + " days"
+		}
+		b.WriteString(fmt.Sprintf("  %-12s on hand %-12s use/day %-10s %s\n",
+			r.Label, fmt.Sprintf("%.0f %s", r.OnHand, r.Unit), fmt.Sprintf("%.0f", r.DailyUse),
+			m.statusStyle(r.Status).Render(runway)))
+	}
+	return b.String()
+}
+
+func (m *model) renderEvents() string {
+	return m.theme.Title.Render("OPERATIONAL EVENT LOG") + "\n\n  " +
+		strings.ReplaceAll(m.eventsBody(20), "\n", "\n  ")
+}
+
+func (m *model) renderPopulation() string {
+	p := m.state.Population
+	var b strings.Builder
+	b.WriteString(m.theme.Title.Render("POPULATION"))
+	b.WriteString("\n\n")
+	b.WriteString(fmt.Sprintf("  Active:        %s\n", m.theme.Value.Render(itoa(p.Active))))
+	b.WriteString(fmt.Sprintf("  Capacity:      %s\n", m.theme.Muted.Render(itoa(p.Capacity))))
+	b.WriteString(fmt.Sprintf("  Load:          %s\n", m.theme.Value.Render(fmt.Sprintf("%.0f%%", p.LoadPct))))
+	b.WriteString(fmt.Sprintf("  Deceased:      %s\n", m.theme.Muted.Render(itoa(p.Deceased))))
+	b.WriteString(fmt.Sprintf("  Births:        %s\n", m.theme.Success.Render(itoa(p.Births))))
+	b.WriteString(fmt.Sprintf("  Deaths:        %s\n", m.theme.Error.Render(itoa(p.Deaths))))
+	b.WriteString(fmt.Sprintf("  Quarantined:   %s\n", m.theme.Warning.Render(itoa(p.Quarantined))))
+	b.WriteString(fmt.Sprintf("  Average age:   %s\n", m.theme.Value.Render(fmt.Sprintf("%.1f", p.AverageAge))))
+	return b.String()
+}
+
+func (m *model) statusStyle(status string) lipgloss.Style {
+	switch status {
+	case "CRITICAL":
+		return m.theme.Error
+	case "WARNING", "WATCH":
+		return m.theme.Warning
+	default:
+		return m.theme.Success
+	}
+}
+
+func (m *model) renderFooter() string {
+	sep := m.theme.DrawHorizontalLine(m.width)
+	hint := "[1]Dashboard [2]Systems [3]Resources [4]Events [5]Population   MANAGED TERMINAL"
+	if m.kiosk {
+		hint = "KIOSK — display managed remotely by overseer console"
+	}
+	return sep + "\n" + m.theme.Footer.Render(hint)
+}
+
+func itoa(n int) string { return fmt.Sprintf("%d", n) }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,35 @@ type Config struct {
 	Display    DisplayConfig    `toml:"display"`
 	Logging    LoggingConfig    `toml:"logging"`
 	Database   DatabaseConfig   `toml:"database"`
+	Exhibit    ExhibitConfig    `toml:"exhibit"`
+	Server     ServerConfig     `toml:"server"`
+	Client     ClientConfig     `toml:"client"`
+}
+
+// ExhibitConfig controls interactive-exhibit presentation behaviours such as the
+// boot sequence and unattended attract (kiosk) mode.
+type ExhibitConfig struct {
+	BootSequence       bool `toml:"boot_sequence"`        // show a boot screen at startup
+	AttractMode        bool `toml:"attract_mode"`         // auto-rotate views when idle
+	AttractIdleSeconds int  `toml:"attract_idle_seconds"` // idle time before attract engages
+	RotateSeconds      int  `toml:"rotate_seconds"`       // seconds per view in attract mode
+	Kiosk              bool `toml:"kiosk"`                // disable quit and destructive actions
+}
+
+// ServerConfig controls the master server (vtuos serve): its listen address,
+// operator authentication, embedded web console, and client management timings.
+type ServerConfig struct {
+	Listen               string `toml:"listen"`                 // e.g. ":8080"
+	AdminToken           string `toml:"admin_token"`            // operator token for control/admin endpoints
+	EnableWeb            bool   `toml:"enable_web"`             // serve the web administration console
+	HeartbeatSeconds     int    `toml:"heartbeat_seconds"`      // client heartbeat cadence
+	ClientTimeoutSeconds int    `toml:"client_timeout_seconds"` // mark a client offline after this silence
+}
+
+// ClientConfig controls the client terminal (vtuos connect).
+type ClientConfig struct {
+	Name string `toml:"name"` // display name reported to the master
+	Kind string `toml:"kind"` // DISPLAY or OPERATOR
 }
 
 // VaultConfig contains vault identity and physical specifications.
@@ -374,6 +403,27 @@ func Default() *Config {
 			Path:                "vault.db",
 			BackupIntervalHours: 24,
 			BackupRetentionDays: 30,
+		},
+		Exhibit: ExhibitConfig{
+			// Off by default: the console behaves as a utilitarian operator tool.
+			// Exhibit deployments enable these in their config (see
+			// testdata/vault-exhibit.toml).
+			BootSequence:       false,
+			AttractMode:        false,
+			AttractIdleSeconds: 120,
+			RotateSeconds:      12,
+			Kiosk:              false,
+		},
+		Server: ServerConfig{
+			Listen:               ":8080",
+			AdminToken:           "",
+			EnableWeb:            true,
+			HeartbeatSeconds:     5,
+			ClientTimeoutSeconds: 20,
+		},
+		Client: ClientConfig{
+			Name: "",
+			Kind: "DISPLAY",
 		},
 	}
 }

--- a/internal/models/resident.go
+++ b/internal/models/resident.go
@@ -137,10 +137,13 @@ func (r *Resident) FullName() string {
 	return fmt.Sprintf("%s, %s", r.Surname, r.GivenNames)
 }
 
-// Age calculates the resident's age as of the given date.
+// Age calculates the resident's age as of the given date. The birthday check
+// compares calendar month and day (rather than day-of-year) so leap years do
+// not introduce an off-by-one error.
 func (r *Resident) Age(asOf time.Time) int {
 	years := asOf.Year() - r.DateOfBirth.Year()
-	if asOf.YearDay() < r.DateOfBirth.YearDay() {
+	if asOf.Month() < r.DateOfBirth.Month() ||
+		(asOf.Month() == r.DateOfBirth.Month() && asOf.Day() < r.DateOfBirth.Day()) {
 		years--
 	}
 	return years

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -1,0 +1,248 @@
+// Package protocol defines the wire types shared between the VT-UOS master
+// server, its web administration console, and connected client terminals.
+//
+// These types are deliberately dependency-free (standard library only) so they
+// can be marshalled to JSON and exchanged over HTTP without coupling the
+// transport layers to the internal domain models. They describe operational
+// state — the same information an operator would read off a control board — not
+// game state.
+package protocol
+
+import "time"
+
+// Version is the protocol revision. Clients and the master compare this on
+// registration to detect incompatible deployments.
+const Version = "1.0"
+
+// SimStatus describes the run state of the simulation control core.
+type SimStatus string
+
+const (
+	// SimStopped indicates the engine is not advancing vault time.
+	SimStopped SimStatus = "STOPPED"
+	// SimRunning indicates the engine is advancing vault time automatically.
+	SimRunning SimStatus = "RUNNING"
+	// SimPaused indicates the engine is loaded but holding vault time steady.
+	SimPaused SimStatus = "PAUSED"
+)
+
+// AlertLevel classifies the severity of an operational alert.
+type AlertLevel string
+
+const (
+	AlertInfo     AlertLevel = "INFO"
+	AlertWarning  AlertLevel = "WARNING"
+	AlertCritical AlertLevel = "CRITICAL"
+)
+
+// Alert is an actionable condition surfaced by the control core.
+type Alert struct {
+	Code         string     `json:"code"`
+	Level        AlertLevel `json:"level"`
+	Message      string     `json:"message"`
+	Subsystem    string     `json:"subsystem"`
+	Raised       time.Time  `json:"raised"`
+	Acknowledged bool       `json:"acknowledged"`
+}
+
+// EventRecord is an entry in the operational event log produced by the engine.
+// Events correspond to real occurrences (equipment faults, spoilage, medical
+// incidents, recovered caches) and are mirrored to the persistent audit log.
+type EventRecord struct {
+	ID       string     `json:"id"`
+	VaultTime time.Time `json:"vault_time"`
+	Category string     `json:"category"`
+	Type     string     `json:"type"`
+	Severity AlertLevel `json:"severity"`
+	Summary  string     `json:"summary"`
+	Detail   string     `json:"detail,omitempty"`
+}
+
+// ResourceStatus summarises a single resource category for the operations board.
+type ResourceStatus struct {
+	Category     string  `json:"category"`
+	Label        string  `json:"label"`
+	OnHand       float64 `json:"on_hand"`
+	Unit         string  `json:"unit"`
+	DailyUse     float64 `json:"daily_use"`
+	RunwayDays   int     `json:"runway_days"` // -1 means effectively unlimited
+	Status       string  `json:"status"`      // OK | WATCH | WARNING | CRITICAL
+	FillFraction float64 `json:"fill_fraction"`
+}
+
+// SystemStatus summarises a single facility system for the operations board.
+type SystemStatus struct {
+	Code       string  `json:"code"`
+	Name       string  `json:"name"`
+	Category   string  `json:"category"`
+	Status     string  `json:"status"`
+	Efficiency float64 `json:"efficiency"`
+	Critical   bool    `json:"critical"`
+}
+
+// PowerStatus describes the vault's electrical balance.
+type PowerStatus struct {
+	GenerationKW  float64 `json:"generation_kw"`
+	ConsumptionKW float64 `json:"consumption_kw"`
+	BalanceKW     float64 `json:"balance_kw"`
+	ReservePct    float64 `json:"reserve_pct"`
+}
+
+// PopulationStatus summarises the census for the operations board.
+type PopulationStatus struct {
+	Active      int     `json:"active"`
+	Capacity    int     `json:"capacity"`
+	Deceased    int     `json:"deceased"`
+	Births      int     `json:"births"`
+	Deaths      int     `json:"deaths"`
+	Quarantined int     `json:"quarantined"`
+	AverageAge  float64 `json:"average_age"`
+	LoadPct     float64 `json:"load_pct"`
+}
+
+// SystemsSummary is the aggregate health of all facility systems.
+type SystemsSummary struct {
+	Total         int     `json:"total"`
+	Operational   int     `json:"operational"`
+	Degraded      int     `json:"degraded"`
+	Offline       int     `json:"offline"`
+	Failed        int     `json:"failed"`
+	AvgEfficiency float64 `json:"avg_efficiency"`
+	OverdueMaint  int     `json:"overdue_maintenance"`
+}
+
+// VaultState is the complete operational snapshot broadcast to clients and the
+// web console. It is rebuilt by the engine after every processed interval.
+type VaultState struct {
+	SchemaVersion string    `json:"schema_version"`
+	Generated     time.Time `json:"generated"`
+
+	// Identity
+	VaultDesignation string `json:"vault_designation"`
+	VaultNumber      int    `json:"vault_number"`
+
+	// Simulation control core
+	Status       SimStatus `json:"status"`
+	TimeScale    float64   `json:"time_scale"`
+	VaultTime    time.Time `json:"vault_time"`
+	SealDate     time.Time `json:"seal_date"`
+	ElapsedDays  int       `json:"elapsed_days"`
+	ElapsedYears int       `json:"elapsed_years"`
+	TickCount    uint64    `json:"tick_count"`
+
+	// Operational telemetry
+	Population PopulationStatus `json:"population"`
+	Resources  []ResourceStatus `json:"resources"`
+	Systems    SystemsSummary   `json:"systems"`
+	SystemList []SystemStatus   `json:"system_list"`
+	Power      PowerStatus      `json:"power"`
+
+	Alerts       []Alert       `json:"alerts"`
+	RecentEvents []EventRecord `json:"recent_events"`
+}
+
+// ClientKind distinguishes how a connected terminal is intended to be used.
+type ClientKind string
+
+const (
+	// ClientDisplay is an unattended exhibit screen (read-only, kiosk).
+	ClientDisplay ClientKind = "DISPLAY"
+	// ClientOperator is an attended operator terminal.
+	ClientOperator ClientKind = "OPERATOR"
+)
+
+// RegisterRequest is sent by a client terminal when it joins the master.
+type RegisterRequest struct {
+	Protocol string     `json:"protocol"`
+	Name     string     `json:"name"`
+	Kind     ClientKind `json:"kind"`
+	Version  string     `json:"version"`
+}
+
+// RegisterResponse is returned to a client that successfully registers.
+type RegisterResponse struct {
+	ClientID         string    `json:"client_id"`
+	Token            string    `json:"token"`
+	Protocol         string    `json:"protocol"`
+	VaultDesignation string    `json:"vault_designation"`
+	ServerTime       time.Time `json:"server_time"`
+	HeartbeatSeconds int       `json:"heartbeat_seconds"`
+}
+
+// Telemetry is the health information a client reports back to the master on
+// each heartbeat — this is the "report back to the server" channel.
+type Telemetry struct {
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	CurrentView   string `json:"current_view"`
+	KioskMode     bool   `json:"kiosk_mode"`
+	FramesRendered uint64 `json:"frames_rendered"`
+	Errors        uint64 `json:"errors"`
+	WidthCols     int    `json:"width_cols"`
+	HeightRows    int    `json:"height_rows"`
+	Note          string `json:"note,omitempty"`
+}
+
+// HeartbeatResponse is returned to a client heartbeat. It carries any pending
+// remote operations the master wants the client to perform.
+type HeartbeatResponse struct {
+	Acknowledged bool      `json:"acknowledged"`
+	ServerTime   time.Time `json:"server_time"`
+	Commands     []Command `json:"commands"`
+}
+
+// CommandType enumerates the remote operations a master may issue to a client.
+type CommandType string
+
+const (
+	CmdSwitchView CommandType = "SWITCH_VIEW" // args: view
+	CmdSetKiosk   CommandType = "SET_KIOSK"   // args: enabled (true|false)
+	CmdMessage    CommandType = "MESSAGE"     // args: text
+	CmdIdentify   CommandType = "IDENTIFY"    // flash an identifying banner
+	CmdRefresh    CommandType = "REFRESH"     // force a state refresh
+	CmdReboot     CommandType = "REBOOT"      // reconnect/restart the client loop
+	CmdShutdown   CommandType = "SHUTDOWN"    // gracefully terminate the client
+)
+
+// Command is a single remote operation targeted at a client terminal.
+type Command struct {
+	ID     string            `json:"id"`
+	Type   CommandType       `json:"type"`
+	Args   map[string]string `json:"args,omitempty"`
+	Issued time.Time         `json:"issued"`
+}
+
+// CommandResult is reported by a client after it executes (or rejects) a command.
+type CommandResult struct {
+	CommandID string    `json:"command_id"`
+	OK        bool      `json:"ok"`
+	Message   string    `json:"message,omitempty"`
+	Completed time.Time `json:"completed"`
+}
+
+// ClientInfo is the master's view of a connected terminal, surfaced to operators
+// in the web console and over the API.
+type ClientInfo struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Kind        ClientKind `json:"kind"`
+	Address     string     `json:"address"`
+	Version     string     `json:"version"`
+	Connected   time.Time  `json:"connected"`
+	LastSeen    time.Time  `json:"last_seen"`
+	Online      bool       `json:"online"`
+	Telemetry   Telemetry  `json:"telemetry"`
+	PendingCmds int        `json:"pending_commands"`
+}
+
+// ControlRequest is the body for simulation control endpoints that take a value
+// (e.g. setting the time scale or stepping a number of hours).
+type ControlRequest struct {
+	TimeScale float64 `json:"time_scale,omitempty"`
+	Hours     int     `json:"hours,omitempty"`
+	Code      string  `json:"code,omitempty"`
+}
+
+// APIError is the standard error envelope returned by the master API.
+type APIError struct {
+	Error string `json:"error"`
+}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -49,13 +49,13 @@ type Alert struct {
 // Events correspond to real occurrences (equipment faults, spoilage, medical
 // incidents, recovered caches) and are mirrored to the persistent audit log.
 type EventRecord struct {
-	ID       string     `json:"id"`
-	VaultTime time.Time `json:"vault_time"`
-	Category string     `json:"category"`
-	Type     string     `json:"type"`
-	Severity AlertLevel `json:"severity"`
-	Summary  string     `json:"summary"`
-	Detail   string     `json:"detail,omitempty"`
+	ID        string     `json:"id"`
+	VaultTime time.Time  `json:"vault_time"`
+	Category  string     `json:"category"`
+	Type      string     `json:"type"`
+	Severity  AlertLevel `json:"severity"`
+	Summary   string     `json:"summary"`
+	Detail    string     `json:"detail,omitempty"`
 }
 
 // ResourceStatus summarises a single resource category for the operations board.
@@ -172,14 +172,14 @@ type RegisterResponse struct {
 // Telemetry is the health information a client reports back to the master on
 // each heartbeat — this is the "report back to the server" channel.
 type Telemetry struct {
-	UptimeSeconds int64  `json:"uptime_seconds"`
-	CurrentView   string `json:"current_view"`
-	KioskMode     bool   `json:"kiosk_mode"`
+	UptimeSeconds  int64  `json:"uptime_seconds"`
+	CurrentView    string `json:"current_view"`
+	KioskMode      bool   `json:"kiosk_mode"`
 	FramesRendered uint64 `json:"frames_rendered"`
-	Errors        uint64 `json:"errors"`
-	WidthCols     int    `json:"width_cols"`
-	HeightRows    int    `json:"height_rows"`
-	Note          string `json:"note,omitempty"`
+	Errors         uint64 `json:"errors"`
+	WidthCols      int    `json:"width_cols"`
+	HeightRows     int    `json:"height_rows"`
+	Note           string `json:"note,omitempty"`
 }
 
 // HeartbeatResponse is returned to a client heartbeat. It carries any pending

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// decodeJSON reads a JSON request body into v with a sane size limit.
+func decodeJSON(r *http.Request, v any) error {
+	dec := json.NewDecoder(http.MaxBytesReader(nil, r.Body, 1<<20))
+	return dec.Decode(v)
+}
+
+// ----- Read endpoints (open) -----
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	st := s.engine.Snapshot()
+	total, online := s.clients.Count()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":         "ok",
+		"protocol":       protocol.Version,
+		"vault":          st.VaultDesignation,
+		"vault_number":   st.VaultNumber,
+		"sim_status":     st.Status,
+		"vault_time":     st.VaultTime,
+		"server_time":    time.Now().UTC(),
+		"clients_total":  total,
+		"clients_online": online,
+	})
+}
+
+func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.engine.Snapshot())
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	st := s.engine.Snapshot()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":        st.Status,
+		"time_scale":    st.TimeScale,
+		"vault_time":    st.VaultTime,
+		"elapsed_days":  st.ElapsedDays,
+		"elapsed_years": st.ElapsedYears,
+		"tick_count":    st.TickCount,
+	})
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	writeJSON(w, http.StatusOK, s.engine.Events(limit))
+}
+
+func (s *Server) handleAlerts(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.engine.Alerts())
+}
+
+func (s *Server) handleSystems(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.engine.Snapshot().SystemList)
+}
+
+func (s *Server) handlePopulation(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.engine.Snapshot().Population)
+}
+
+func (s *Server) handleResources(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.engine.Snapshot().Resources)
+}
+
+// ----- Simulation control endpoints (admin) -----
+
+func (s *Server) handleSimPause(w http.ResponseWriter, r *http.Request) {
+	s.engine.Pause()
+	s.log.Info("simulation paused via API", "by", r.RemoteAddr)
+	writeJSON(w, http.StatusOK, s.engine.Snapshot())
+}
+
+func (s *Server) handleSimResume(w http.ResponseWriter, r *http.Request) {
+	s.engine.Resume()
+	s.log.Info("simulation resumed via API", "by", r.RemoteAddr)
+	writeJSON(w, http.StatusOK, s.engine.Snapshot())
+}
+
+func (s *Server) handleSimScale(w http.ResponseWriter, r *http.Request) {
+	var req protocol.ControlRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.engine.SetTimeScale(req.TimeScale); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.log.Info("time scale changed via API", "scale", req.TimeScale, "by", r.RemoteAddr)
+	writeJSON(w, http.StatusOK, s.engine.Snapshot())
+}
+
+func (s *Server) handleSimStep(w http.ResponseWriter, r *http.Request) {
+	var req protocol.ControlRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	hours := req.Hours
+	if hours <= 0 {
+		hours = 24
+	}
+	if hours > 8760 {
+		hours = 8760 // cap a single manual step to one simulated year
+	}
+	if err := s.engine.Step(r.Context(), hours); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.log.Info("simulation stepped via API", "hours", hours, "by", r.RemoteAddr)
+	writeJSON(w, http.StatusOK, s.engine.Snapshot())
+}
+
+func (s *Server) handleSimSnapshot(w http.ResponseWriter, r *http.Request) {
+	path, err := s.engine.CreateSnapshot(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"snapshot": path})
+}
+
+func (s *Server) handleAckAlert(w http.ResponseWriter, r *http.Request) {
+	var req protocol.ControlRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	ok := s.engine.AcknowledgeAlert(req.Code)
+	writeJSON(w, http.StatusOK, map[string]bool{"acknowledged": ok})
+}
+
+// ----- Client management endpoints -----
+
+func (s *Server) handleClientRegister(w http.ResponseWriter, r *http.Request) {
+	var req protocol.RegisterRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Protocol != "" && req.Protocol != protocol.Version {
+		writeError(w, http.StatusConflict, "protocol version mismatch")
+		return
+	}
+	resp := s.clients.Register(req, r.RemoteAddr)
+	resp.VaultDesignation = s.cfg.Vault.Designation
+	resp.HeartbeatSeconds = s.heartbeatSeconds()
+	s.log.Info("client registered", "id", resp.ClientID, "name", req.Name, "addr", r.RemoteAddr)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleClientHeartbeat(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	token := r.Header.Get("X-Client-Token")
+	var tel protocol.Telemetry
+	if err := decodeJSON(r, &tel); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid telemetry body")
+		return
+	}
+	cmds, ok := s.clients.Heartbeat(id, token, tel)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "unknown client or bad token")
+		return
+	}
+	writeJSON(w, http.StatusOK, protocol.HeartbeatResponse{
+		Acknowledged: true,
+		ServerTime:   time.Now().UTC(),
+		Commands:     cmds,
+	})
+}
+
+func (s *Server) handleClientResult(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	token := r.Header.Get("X-Client-Token")
+	var res protocol.CommandResult
+	if err := decodeJSON(r, &res); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid result body")
+		return
+	}
+	if !s.clients.ReportResult(id, token, res) {
+		writeError(w, http.StatusUnauthorized, "unknown client or bad token")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleClientList(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.clients.List())
+}
+
+func (s *Server) handleClientCommand(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var cmd protocol.Command
+	if err := decodeJSON(r, &cmd); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid command body")
+		return
+	}
+	if cmd.Type == "" {
+		writeError(w, http.StatusBadRequest, "command type required")
+		return
+	}
+	if !s.clients.IssueCommand(id, cmd) {
+		writeError(w, http.StatusNotFound, "unknown client")
+		return
+	}
+	s.log.Info("remote operation queued", "client", id, "type", cmd.Type, "by", r.RemoteAddr)
+	writeJSON(w, http.StatusAccepted, map[string]string{"queued": string(cmd.Type)})
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -9,9 +9,11 @@ import (
 	"github.com/vtuos/vtuos/internal/protocol"
 )
 
-// decodeJSON reads a JSON request body into v with a sane size limit.
-func decodeJSON(r *http.Request, v any) error {
-	dec := json.NewDecoder(http.MaxBytesReader(nil, r.Body, 1<<20))
+// decodeJSON reads a JSON request body into v with a sane size limit. The
+// ResponseWriter is passed to MaxBytesReader so an oversized body produces a
+// proper 413 response and the connection is handled correctly.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) error {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
 	return dec.Decode(v)
 }
 
@@ -91,7 +93,7 @@ func (s *Server) handleSimResume(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSimScale(w http.ResponseWriter, r *http.Request) {
 	var req protocol.ControlRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := decodeJSON(w, r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -105,7 +107,7 @@ func (s *Server) handleSimScale(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSimStep(w http.ResponseWriter, r *http.Request) {
 	var req protocol.ControlRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := decodeJSON(w, r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -117,7 +119,8 @@ func (s *Server) handleSimStep(w http.ResponseWriter, r *http.Request) {
 		hours = 8760 // cap a single manual step to one simulated year
 	}
 	if err := s.engine.Step(r.Context(), hours); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.log.Error("simulation step via API failed", "hours", hours, "error", err)
+		writeError(w, http.StatusInternalServerError, "simulation step failed")
 		return
 	}
 	s.log.Info("simulation stepped via API", "hours", hours, "by", r.RemoteAddr)
@@ -127,7 +130,8 @@ func (s *Server) handleSimStep(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSimSnapshot(w http.ResponseWriter, r *http.Request) {
 	path, err := s.engine.CreateSnapshot(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.log.Error("snapshot via API failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "snapshot creation failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"snapshot": path})
@@ -135,7 +139,7 @@ func (s *Server) handleSimSnapshot(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAckAlert(w http.ResponseWriter, r *http.Request) {
 	var req protocol.ControlRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := decodeJSON(w, r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -147,7 +151,7 @@ func (s *Server) handleAckAlert(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleClientRegister(w http.ResponseWriter, r *http.Request) {
 	var req protocol.RegisterRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := decodeJSON(w, r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -166,7 +170,7 @@ func (s *Server) handleClientHeartbeat(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	token := r.Header.Get("X-Client-Token")
 	var tel protocol.Telemetry
-	if err := decodeJSON(r, &tel); err != nil {
+	if err := decodeJSON(w, r, &tel); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid telemetry body")
 		return
 	}
@@ -186,7 +190,7 @@ func (s *Server) handleClientResult(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	token := r.Header.Get("X-Client-Token")
 	var res protocol.CommandResult
-	if err := decodeJSON(r, &res); err != nil {
+	if err := decodeJSON(w, r, &res); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid result body")
 		return
 	}
@@ -204,7 +208,7 @@ func (s *Server) handleClientList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleClientCommand(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	var cmd protocol.Command
-	if err := decodeJSON(r, &cmd); err != nil {
+	if err := decodeJSON(w, r, &cmd); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid command body")
 		return
 	}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// writeJSON encodes v as a JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes a JSON error envelope.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, protocol.APIError{Error: msg})
+}
+
+// adminToken extracts the operator token from the request, accepting either an
+// Authorization: Bearer header or an X-Admin-Token header.
+func adminToken(r *http.Request) string {
+	if h := r.Header.Get("Authorization"); h != "" {
+		if strings.HasPrefix(strings.ToLower(h), "bearer ") {
+			return strings.TrimSpace(h[7:])
+		}
+	}
+	return r.Header.Get("X-Admin-Token")
+}
+
+// adminAuthorized reports whether the request carries a valid operator token.
+// When no admin token is configured the control surface is open (and a warning
+// is logged at startup).
+func (s *Server) adminAuthorized(r *http.Request) bool {
+	if s.cfg.Server.AdminToken == "" {
+		return true
+	}
+	return adminToken(r) == s.cfg.Server.AdminToken
+}
+
+// requireAdmin wraps a handler so it only runs for authorised operators.
+func (s *Server) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !s.adminAuthorized(r) {
+			writeError(w, http.StatusUnauthorized, "operator token required")
+			return
+		}
+		next(w, r)
+	}
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -13,7 +14,9 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Debug("encoding JSON response failed", "error", err)
+	}
 }
 
 // writeError writes a JSON error envelope.

--- a/internal/server/clients.go
+++ b/internal/server/clients.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"sync"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/util"
+)
+
+// clientEntry is the master's record of a connected terminal.
+type clientEntry struct {
+	info    protocol.ClientInfo
+	token   string
+	pending []protocol.Command
+	results []protocol.CommandResult
+}
+
+// ClientRegistry tracks connected client terminals, the remote-operation queue
+// for each, and their reported telemetry. It is safe for concurrent use.
+type ClientRegistry struct {
+	mu      sync.RWMutex
+	clients map[string]*clientEntry
+	timeout time.Duration
+	idGen   *util.IDGenerator
+	nowFn   func() time.Time
+}
+
+// NewClientRegistry creates a registry that considers a client offline after it
+// has been silent for longer than timeout.
+func NewClientRegistry(timeout time.Duration) *ClientRegistry {
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	return &ClientRegistry{
+		clients: make(map[string]*clientEntry),
+		timeout: timeout,
+		idGen:   util.NewIDGenerator(),
+		nowFn:   time.Now,
+	}
+}
+
+// Register admits a new client terminal and returns its assigned id and token.
+func (r *ClientRegistry) Register(req protocol.RegisterRequest, addr string) protocol.RegisterResponse {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	id := r.idGen.NewID()
+	token := r.idGen.NewID()
+	now := r.nowFn()
+	kind := req.Kind
+	if kind != protocol.ClientOperator {
+		kind = protocol.ClientDisplay
+	}
+	name := req.Name
+	if name == "" {
+		name = "terminal-" + id[:8]
+	}
+
+	r.clients[id] = &clientEntry{
+		token: token,
+		info: protocol.ClientInfo{
+			ID:        id,
+			Name:      name,
+			Kind:      kind,
+			Address:   addr,
+			Version:   req.Version,
+			Connected: now,
+			LastSeen:  now,
+			Online:    true,
+		},
+	}
+	return protocol.RegisterResponse{
+		ClientID:   id,
+		Token:      token,
+		Protocol:   protocol.Version,
+		ServerTime: now,
+	}
+}
+
+// Heartbeat records a client's telemetry and returns (and clears) any pending
+// remote operations queued for it.
+func (r *ClientRegistry) Heartbeat(id, token string, tel protocol.Telemetry) ([]protocol.Command, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c, ok := r.clients[id]
+	if !ok || c.token != token {
+		return nil, false
+	}
+	c.info.LastSeen = r.nowFn()
+	c.info.Online = true
+	c.info.Telemetry = tel
+	cmds := c.pending
+	c.pending = nil
+	c.info.PendingCmds = 0
+	return cmds, true
+}
+
+// ReportResult records the outcome of a remote operation reported by a client.
+func (r *ClientRegistry) ReportResult(id, token string, res protocol.CommandResult) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c, ok := r.clients[id]
+	if !ok || c.token != token {
+		return false
+	}
+	c.results = append(c.results, res)
+	if len(c.results) > 20 {
+		c.results = c.results[len(c.results)-20:]
+	}
+	return true
+}
+
+// IssueCommand queues a remote operation for the given client.
+func (r *ClientRegistry) IssueCommand(id string, cmd protocol.Command) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c, ok := r.clients[id]
+	if !ok {
+		return false
+	}
+	if cmd.ID == "" {
+		cmd.ID = r.idGen.NewID()
+	}
+	if cmd.Issued.IsZero() {
+		cmd.Issued = r.nowFn()
+	}
+	c.pending = append(c.pending, cmd)
+	c.info.PendingCmds = len(c.pending)
+	return true
+}
+
+// List returns a snapshot of all known clients with online status computed from
+// the heartbeat timeout.
+func (r *ClientRegistry) List() []protocol.ClientInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	now := r.nowFn()
+	out := make([]protocol.ClientInfo, 0, len(r.clients))
+	for _, c := range r.clients {
+		info := c.info
+		info.Online = now.Sub(info.LastSeen) < r.timeout
+		info.PendingCmds = len(c.pending)
+		out = append(out, info)
+	}
+	return out
+}
+
+// Get returns a single client's info, or false if unknown.
+func (r *ClientRegistry) Get(id string) (protocol.ClientInfo, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.clients[id]
+	if !ok {
+		return protocol.ClientInfo{}, false
+	}
+	info := c.info
+	info.Online = r.nowFn().Sub(info.LastSeen) < r.timeout
+	info.PendingCmds = len(c.pending)
+	return info, true
+}
+
+// Count returns the number of clients and how many are currently online.
+func (r *ClientRegistry) Count() (total, online int) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	now := r.nowFn()
+	for _, c := range r.clients {
+		total++
+		if now.Sub(c.info.LastSeen) < r.timeout {
+			online++
+		}
+	}
+	return total, online
+}

--- a/internal/server/clients.go
+++ b/internal/server/clients.go
@@ -111,6 +111,11 @@ func (r *ClientRegistry) ReportResult(id, token string, res protocol.CommandResu
 	return true
 }
 
+// maxPendingCommands bounds the per-client remote-operation queue so an
+// operator (or a buggy caller) issuing commands to an offline terminal cannot
+// grow memory without limit.
+const maxPendingCommands = 64
+
 // IssueCommand queues a remote operation for the given client.
 func (r *ClientRegistry) IssueCommand(id string, cmd protocol.Command) bool {
 	r.mu.Lock()
@@ -126,8 +131,29 @@ func (r *ClientRegistry) IssueCommand(id string, cmd protocol.Command) bool {
 		cmd.Issued = r.nowFn()
 	}
 	c.pending = append(c.pending, cmd)
+	if len(c.pending) > maxPendingCommands {
+		// Drop the oldest queued operations, keeping the most recent.
+		c.pending = c.pending[len(c.pending)-maxPendingCommands:]
+	}
 	c.info.PendingCmds = len(c.pending)
 	return true
+}
+
+// CleanupStale removes clients that have been silent for longer than maxAge,
+// reclaiming their entries and any queued commands. It returns the number
+// removed.
+func (r *ClientRegistry) CleanupStale(maxAge time.Duration) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.nowFn()
+	removed := 0
+	for id, c := range r.clients {
+		if now.Sub(c.info.LastSeen) > maxAge {
+			delete(r.clients, id)
+			removed++
+		}
+	}
+	return removed
 }
 
 // List returns a snapshot of all known clients with online status computed from

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ type Server struct {
 	clients *ClientRegistry
 	log     *slog.Logger
 	httpSrv *http.Server
+	done    chan struct{}
 }
 
 // New constructs a master server bound to the given control core and config.
@@ -36,6 +37,7 @@ func New(engine *simulation.Engine, cfg *config.Config) (*Server, error) {
 		cfg:     cfg,
 		clients: NewClientRegistry(timeout),
 		log:     slog.Default().With("component", "server"),
+		done:    make(chan struct{}),
 	}
 	s.httpSrv = &http.Server{
 		Addr:              cfg.Server.Listen,
@@ -111,14 +113,42 @@ func (s *Server) Start() error {
 		"web_console", s.cfg.Server.EnableWeb,
 		"vault", s.cfg.Vault.Designation,
 	)
+	go s.cleanupLoop()
 	if err := s.httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("http server: %w", err)
 	}
 	return nil
 }
 
+// cleanupLoop periodically reclaims client entries that have gone silent well
+// past their timeout, bounding registry memory over long-running deployments.
+func (s *Server) cleanupLoop() {
+	timeout := time.Duration(s.cfg.Server.ClientTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	maxAge := timeout * 10
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			if n := s.clients.CleanupStale(maxAge); n > 0 {
+				s.log.Info("reclaimed stale client terminals", "count", n)
+			}
+		}
+	}
+}
+
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown(ctx context.Context) error {
+	select {
+	case <-s.done:
+	default:
+		close(s.done)
+	}
 	return s.httpSrv.Shutdown(ctx)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,134 @@
+// Package server implements the VT-UOS master server: an authoritative
+// simulation host that exposes operational state and control over a stdlib
+// net/http JSON API, streams live state via Server-Sent Events, manages
+// connected client terminals (registration, telemetry, and remote operations),
+// and serves an embedded web administration console.
+//
+// It uses only the Go standard library for transport — no web framework — in
+// keeping with the project's single-static-binary constraint.
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/config"
+	"github.com/vtuos/vtuos/internal/simulation"
+)
+
+// Server is the master server.
+type Server struct {
+	engine  *simulation.Engine
+	cfg     *config.Config
+	clients *ClientRegistry
+	log     *slog.Logger
+	httpSrv *http.Server
+}
+
+// New constructs a master server bound to the given control core and config.
+func New(engine *simulation.Engine, cfg *config.Config) (*Server, error) {
+	timeout := time.Duration(cfg.Server.ClientTimeoutSeconds) * time.Second
+	s := &Server{
+		engine:  engine,
+		cfg:     cfg,
+		clients: NewClientRegistry(timeout),
+		log:     slog.Default().With("component", "server"),
+	}
+	s.httpSrv = &http.Server{
+		Addr:              cfg.Server.Listen,
+		Handler:           s.routes(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return s, nil
+}
+
+// Registry exposes the client registry (used by tests and introspection).
+func (s *Server) Registry() *ClientRegistry { return s.clients }
+
+func (s *Server) heartbeatSeconds() int {
+	if s.cfg.Server.HeartbeatSeconds > 0 {
+		return s.cfg.Server.HeartbeatSeconds
+	}
+	return 5
+}
+
+// routes builds the HTTP request multiplexer.
+func (s *Server) routes() http.Handler {
+	mux := http.NewServeMux()
+
+	// Liveness and machine-readable health.
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+	mux.HandleFunc("GET /api/v1/health", s.handleHealth)
+
+	// Operational read endpoints (open so display terminals can poll freely).
+	mux.HandleFunc("GET /api/v1/state", s.handleState)
+	mux.HandleFunc("GET /api/v1/status", s.handleStatus)
+	mux.HandleFunc("GET /api/v1/events", s.handleEvents)
+	mux.HandleFunc("GET /api/v1/alerts", s.handleAlerts)
+	mux.HandleFunc("GET /api/v1/systems", s.handleSystems)
+	mux.HandleFunc("GET /api/v1/population", s.handlePopulation)
+	mux.HandleFunc("GET /api/v1/resources", s.handleResources)
+	mux.HandleFunc("GET /api/v1/stream", s.handleStream)
+
+	// Simulation control (operator token required).
+	mux.HandleFunc("POST /api/v1/sim/pause", s.requireAdmin(s.handleSimPause))
+	mux.HandleFunc("POST /api/v1/sim/resume", s.requireAdmin(s.handleSimResume))
+	mux.HandleFunc("POST /api/v1/sim/scale", s.requireAdmin(s.handleSimScale))
+	mux.HandleFunc("POST /api/v1/sim/step", s.requireAdmin(s.handleSimStep))
+	mux.HandleFunc("POST /api/v1/sim/snapshot", s.requireAdmin(s.handleSimSnapshot))
+	mux.HandleFunc("POST /api/v1/sim/ack", s.requireAdmin(s.handleAckAlert))
+
+	// Client terminals: registration/heartbeat/result use per-client tokens.
+	mux.HandleFunc("POST /api/v1/clients/register", s.handleClientRegister)
+	mux.HandleFunc("POST /api/v1/clients/{id}/heartbeat", s.handleClientHeartbeat)
+	mux.HandleFunc("POST /api/v1/clients/{id}/result", s.handleClientResult)
+
+	// Client management (operator token required).
+	mux.HandleFunc("GET /api/v1/clients", s.requireAdmin(s.handleClientList))
+	mux.HandleFunc("POST /api/v1/clients/{id}/command", s.requireAdmin(s.handleClientCommand))
+
+	// Embedded web administration console.
+	if s.cfg.Server.EnableWeb {
+		s.registerWebRoutes(mux)
+	}
+
+	return logRequests(s.log, mux)
+}
+
+// Start begins serving and blocks until the server is shut down.
+func (s *Server) Start() error {
+	if s.cfg.Server.AdminToken == "" {
+		s.log.Warn("no admin_token configured: simulation control and client management endpoints are UNAUTHENTICATED")
+	}
+	s.log.Info("master server listening",
+		"addr", s.cfg.Server.Listen,
+		"web_console", s.cfg.Server.EnableWeb,
+		"vault", s.cfg.Vault.Designation,
+	)
+	if err := s.httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("http server: %w", err)
+	}
+	return nil
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpSrv.Shutdown(ctx)
+}
+
+// logRequests is a lightweight access-logging middleware.
+func logRequests(log *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The state stream is long-lived; don't log it per-request beyond open.
+		if r.URL.Path == "/api/v1/stream" {
+			log.Debug("stream opened", "remote", r.RemoteAddr)
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/config"
+	"github.com/vtuos/vtuos/internal/database"
+	"github.com/vtuos/vtuos/internal/database/seed"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/simulation"
+	"github.com/vtuos/vtuos/internal/util"
+)
+
+func newTestServer(t *testing.T) (*Server, *simulation.Engine) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := database.NewInMemory()
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	mig, err := database.NewMigrator(db)
+	if err != nil {
+		t.Fatalf("migrator: %v", err)
+	}
+	if _, err := mig.MigrateUp(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.Simulation.Enabled = false
+	cfg.Server.AdminToken = "secret"
+	cfg.Server.EnableWeb = true
+
+	sealDate := time.Date(2077, 10, 23, 9, 47, 0, 0, time.UTC)
+	if err := seed.NewGenerator(db.DB, seed.Config{
+		VaultNumber: 76, SealDate: sealDate, TargetPopulation: 60,
+		FamilyHouseholds: 8, SingleHouseholds: 8, RandomSeed: 7,
+	}).Generate(ctx); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	clock := util.NewVaultClock(sealDate, 60)
+	clock.Pause()
+	eng := simulation.New(db, cfg, clock)
+	if err := eng.Start(ctx); err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+	t.Cleanup(func() { eng.Stop(context.Background()) })
+
+	srv, err := New(eng, cfg)
+	if err != nil {
+		t.Fatalf("server: %v", err)
+	}
+	return srv, eng
+}
+
+func do(t *testing.T, h http.Handler, method, path string, body any, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestServerHealthAndState(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.routes()
+
+	if rec := do(t, h, "GET", "/healthz", nil, nil); rec.Code != 200 {
+		t.Fatalf("healthz code = %d", rec.Code)
+	}
+
+	rec := do(t, h, "GET", "/api/v1/state", nil, nil)
+	if rec.Code != 200 {
+		t.Fatalf("state code = %d", rec.Code)
+	}
+	var st protocol.VaultState
+	if err := json.Unmarshal(rec.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	if st.SchemaVersion != protocol.Version {
+		t.Errorf("schema = %q", st.SchemaVersion)
+	}
+	if st.Population.Active == 0 {
+		t.Error("expected active population in state")
+	}
+	if st.Systems.Total == 0 {
+		t.Error("expected systems in state")
+	}
+}
+
+func TestServerControlRequiresToken(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.routes()
+
+	// Without the operator token, control is rejected.
+	if rec := do(t, h, "POST", "/api/v1/sim/pause", nil, nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", rec.Code)
+	}
+	// With the token, control succeeds.
+	rec := do(t, h, "POST", "/api/v1/sim/pause", nil, map[string]string{"X-Admin-Token": "secret"})
+	if rec.Code != 200 {
+		t.Fatalf("expected 200 with token, got %d", rec.Code)
+	}
+}
+
+func TestServerSimStep(t *testing.T) {
+	srv, eng := newTestServer(t)
+	h := srv.routes()
+	before := eng.TickCount()
+	rec := do(t, h, "POST", "/api/v1/sim/step", protocol.ControlRequest{Hours: 48},
+		map[string]string{"X-Admin-Token": "secret"})
+	if rec.Code != 200 {
+		t.Fatalf("step code = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if eng.TickCount() < before+48 {
+		t.Errorf("expected tick count to advance by 48 (before=%d after=%d)", before, eng.TickCount())
+	}
+}
+
+func TestServerClientLifecycleAndRemoteOps(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.routes()
+	admin := map[string]string{"X-Admin-Token": "secret"}
+
+	// Register a client terminal.
+	rec := do(t, h, "POST", "/api/v1/clients/register",
+		protocol.RegisterRequest{Protocol: protocol.Version, Name: "Atrium", Kind: protocol.ClientDisplay}, nil)
+	if rec.Code != 200 {
+		t.Fatalf("register code = %d", rec.Code)
+	}
+	var reg protocol.RegisterResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("decode register: %v", err)
+	}
+	if reg.ClientID == "" || reg.Token == "" {
+		t.Fatal("expected client id and token")
+	}
+
+	// Operator issues a remote operation.
+	rec = do(t, h, "POST", "/api/v1/clients/"+reg.ClientID+"/command",
+		protocol.Command{Type: protocol.CmdIdentify}, admin)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("command code = %d", rec.Code)
+	}
+
+	// Client heartbeats and receives the queued command.
+	rec = do(t, h, "POST", "/api/v1/clients/"+reg.ClientID+"/heartbeat",
+		protocol.Telemetry{CurrentView: "dashboard"},
+		map[string]string{"X-Client-Token": reg.Token})
+	if rec.Code != 200 {
+		t.Fatalf("heartbeat code = %d", rec.Code)
+	}
+	var hb protocol.HeartbeatResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &hb); err != nil {
+		t.Fatalf("decode heartbeat: %v", err)
+	}
+	if len(hb.Commands) != 1 || hb.Commands[0].Type != protocol.CmdIdentify {
+		t.Fatalf("expected one IDENTIFY command, got %+v", hb.Commands)
+	}
+
+	// A bad client token is rejected.
+	rec = do(t, h, "POST", "/api/v1/clients/"+reg.ClientID+"/heartbeat",
+		protocol.Telemetry{}, map[string]string{"X-Client-Token": "wrong"})
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for bad client token, got %d", rec.Code)
+	}
+
+	// Operator lists terminals and sees the registered client.
+	rec = do(t, h, "GET", "/api/v1/clients", nil, admin)
+	if rec.Code != 200 {
+		t.Fatalf("clients list code = %d", rec.Code)
+	}
+	var list []protocol.ClientInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode clients: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "Atrium" {
+		t.Fatalf("expected one client 'Atrium', got %+v", list)
+	}
+}
+
+func TestServerWebConsoleServes(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.routes()
+	rec := do(t, h, "GET", "/", nil, nil)
+	if rec.Code != 200 {
+		t.Fatalf("console code = %d", rec.Code)
+	}
+	if body := rec.Body.String(); !bytes.Contains([]byte(body), []byte("UNIFIED OPERATING SYSTEM")) {
+		t.Error("expected console HTML")
+	}
+	if rec := do(t, h, "GET", "/static/app.js", nil, nil); rec.Code != 200 {
+		t.Errorf("static asset code = %d", rec.Code)
+	}
+}

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// handleStream serves the live operational state as Server-Sent Events. Each
+// connection subscribes to the control core and receives a fresh VaultState
+// frame whenever the engine recomputes, plus periodic keep-alive comments.
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	id, ch := s.engine.Subscribe()
+	defer s.engine.Unsubscribe(id)
+
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-keepAlive.C:
+			fmt.Fprint(w, ": keep-alive\n\n")
+			flusher.Flush()
+		case st, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(st)
+			if err != nil {
+				continue
+			}
+			fmt.Fprintf(w, "event: state\ndata: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/server/web.go
+++ b/internal/server/web.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"embed"
+	"html/template"
+	"io/fs"
+	"net/http"
+)
+
+//go:embed web/index.html.tmpl web/static/*
+var webFS embed.FS
+
+// webData is injected into the console template.
+type webData struct {
+	Vault       string
+	VaultNumber int
+	Protocol    string
+	Heartbeat   int
+}
+
+// registerWebRoutes mounts the embedded web administration console.
+func (s *Server) registerWebRoutes(mux *http.ServeMux) {
+	tmpl := template.Must(template.ParseFS(webFS, "web/index.html.tmpl"))
+
+	staticFS, err := fs.Sub(webFS, "web/static")
+	if err != nil {
+		s.log.Error("loading web assets failed", "error", err)
+		return
+	}
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = tmpl.Execute(w, webData{
+			Vault:       s.cfg.Vault.Designation,
+			VaultNumber: s.cfg.Vault.Number,
+			Protocol:    "1.0",
+			Heartbeat:   s.heartbeatSeconds(),
+		})
+	})
+}

--- a/internal/server/web/index.html.tmpl
+++ b/internal/server/web/index.html.tmpl
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VT-UOS · {{.Vault}} · Overseer Console</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <header class="bar">
+    <div class="brand">
+      <span class="logo">▣</span>
+      <span class="title">VAULT-TEC UNIFIED OPERATING SYSTEM</span>
+    </div>
+    <div class="ident">
+      <span id="vaultName">{{.Vault}}</span>
+      <span class="sep">│</span>
+      <span id="simStatus" class="status">—</span>
+      <span class="sep">│</span>
+      <span id="vaultTime">----</span>
+    </div>
+  </header>
+
+  <div class="tokenbar">
+    <label>OVERSEER TOKEN
+      <input id="token" type="password" placeholder="operator token (if required)" autocomplete="off">
+    </label>
+    <button id="saveToken">SET</button>
+    <span id="conn" class="conn off">OFFLINE</span>
+  </div>
+
+  <nav class="tabs">
+    <button class="tab active" data-tab="overview">OVERVIEW</button>
+    <button class="tab" data-tab="simulation">SIMULATION</button>
+    <button class="tab" data-tab="systems">SYSTEMS</button>
+    <button class="tab" data-tab="clients">TERMINALS</button>
+    <button class="tab" data-tab="events">EVENT LOG</button>
+  </nav>
+
+  <main>
+    <section id="overview" class="panel active">
+      <div class="grid">
+        <div class="card"><h2>POPULATION</h2><div id="popCard"></div></div>
+        <div class="card"><h2>POWER</h2><div id="powerCard"></div></div>
+        <div class="card"><h2>SYSTEMS</h2><div id="sysSummary"></div></div>
+        <div class="card"><h2>RESOURCE RUNWAY</h2><div id="resCard"></div></div>
+        <div class="card wide"><h2>ACTIVE ALERTS</h2><div id="alertsCard"></div></div>
+      </div>
+    </section>
+
+    <section id="simulation" class="panel">
+      <div class="card">
+        <h2>CONTROL CORE</h2>
+        <div id="simInfo"></div>
+        <div class="controls">
+          <button data-act="resume">▶ RESUME</button>
+          <button data-act="pause">‖ PAUSE</button>
+          <button data-act="step" data-hours="1">STEP 1h</button>
+          <button data-act="step" data-hours="24">STEP 1d</button>
+          <button data-act="step" data-hours="168">STEP 1w</button>
+          <button data-act="snapshot">⤓ SNAPSHOT</button>
+        </div>
+        <div class="controls">
+          <label>TIME SCALE
+            <select id="scaleSel">
+              <option value="0">Frozen</option>
+              <option value="1">1× (real time)</option>
+              <option value="60">60× (1 min → 1 hr)</option>
+              <option value="600">600×</option>
+              <option value="1440">1440× (1 min → 1 day)</option>
+              <option value="3600">3600×</option>
+              <option value="14400">14400×</option>
+              <option value="86400">86400× (1 sec → 1 day)</option>
+            </select>
+          </label>
+          <button data-act="scale">APPLY SCALE</button>
+        </div>
+        <p id="simMsg" class="msg"></p>
+      </div>
+    </section>
+
+    <section id="systems" class="panel">
+      <div class="card"><h2>FACILITY SYSTEMS</h2><table id="sysTable"><thead><tr>
+        <th>CODE</th><th>NAME</th><th>CATEGORY</th><th>STATUS</th><th>EFFICIENCY</th></tr></thead>
+        <tbody></tbody></table></div>
+    </section>
+
+    <section id="clients" class="panel">
+      <div class="card"><h2>CONNECTED TERMINALS</h2>
+        <p class="hint">Issue remote operations to managed display terminals. Operator token required.</p>
+        <table id="cliTable"><thead><tr>
+          <th>NAME</th><th>KIND</th><th>STATE</th><th>VIEW</th><th>ADDRESS</th><th>LAST SEEN</th><th>REMOTE OPS</th>
+        </tr></thead><tbody></tbody></table>
+      </div>
+    </section>
+
+    <section id="events" class="panel">
+      <div class="card"><h2>OPERATIONAL EVENT LOG</h2><div id="eventList"></div></div>
+    </section>
+  </main>
+
+  <footer class="bar foot">
+    <span>RobCo Industries (TM) · Overseer Terminal</span>
+    <span>Protocol {{.Protocol}}</span>
+  </footer>
+
+  <script>
+    window.VTUOS = { protocol: "{{.Protocol}}", heartbeat: {{.Heartbeat}}, vaultNumber: {{.VaultNumber}} };
+  </script>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -163,7 +163,7 @@ async function refreshClients() {
 
 window.op = async function (id, type) {
   const args = {};
-  if (type === "SWITCH_VIEW") { const v = prompt("View (dashboard, population, resources, facilities, simulation, security):", "dashboard"); if (!v) return; args.view = v; }
+  if (type === "SWITCH_VIEW") { const v = prompt("View (dashboard, systems, resources, events, population):", "dashboard"); if (!v) return; args.view = v; }
   if (type === "MESSAGE") { const t = prompt("Message to display:"); if (!t) return; args.text = t; }
   if (type === "SET_KIOSK") { args.enabled = confirm("Enable kiosk mode? OK = enable, Cancel = disable") ? "true" : "false"; }
   try { await post(`/api/v1/clients/${id}/command`, { type, args }); setMsg(`Queued ${type} for terminal.`); refreshClients(); }

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const cfg = window.VTUOS || { heartbeat: 5 };
+let token = localStorage.getItem("vtuos_token") || "";
+
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+function authHeaders() {
+  const h = { "Content-Type": "application/json" };
+  if (token) h["X-Admin-Token"] = token;
+  return h;
+}
+
+async function post(path, body) {
+  const r = await fetch(path, { method: "POST", headers: authHeaders(), body: JSON.stringify(body || {}) });
+  if (!r.ok) {
+    const e = await r.json().catch(() => ({ error: r.statusText }));
+    throw new Error(e.error || ("HTTP " + r.status));
+  }
+  return r.json().catch(() => ({}));
+}
+
+function setMsg(t, isErr) {
+  const m = $("simMsg");
+  if (!m) return;
+  m.textContent = t || "";
+  m.style.color = isErr ? "var(--red)" : "var(--amber)";
+}
+
+// ---- Token bar ----
+$("token").value = token;
+$("saveToken").onclick = () => {
+  token = $("token").value.trim();
+  localStorage.setItem("vtuos_token", token);
+  setMsg("Operator token set.");
+};
+
+// ---- Tabs ----
+document.querySelectorAll(".tab").forEach((t) => {
+  t.onclick = () => {
+    document.querySelectorAll(".tab").forEach((x) => x.classList.remove("active"));
+    document.querySelectorAll(".panel").forEach((x) => x.classList.remove("active"));
+    t.classList.add("active");
+    $(t.dataset.tab).classList.add("active");
+    if (t.dataset.tab === "clients") refreshClients();
+    if (t.dataset.tab === "events") refreshEvents();
+  };
+});
+
+// ---- Simulation controls ----
+document.querySelectorAll("[data-act]").forEach((b) => {
+  b.onclick = async () => {
+    try {
+      const act = b.dataset.act;
+      if (act === "pause") await post("/api/v1/sim/pause");
+      else if (act === "resume") await post("/api/v1/sim/resume");
+      else if (act === "step") await post("/api/v1/sim/step", { hours: parseInt(b.dataset.hours, 10) });
+      else if (act === "snapshot") { const r = await post("/api/v1/sim/snapshot"); setMsg("Snapshot saved: " + r.snapshot); return; }
+      else if (act === "scale") await post("/api/v1/sim/scale", { time_scale: parseFloat($("scaleSel").value) });
+      setMsg(act + " ok.");
+    } catch (e) { setMsg(e.message, true); }
+  };
+});
+
+// ---- Live state via SSE ----
+function pct(v) { return Math.max(0, Math.min(100, v || 0)); }
+function statusClass(s) { return s === "CRITICAL" ? "crit" : s === "WARNING" ? "warn" : s === "WATCH" ? "warn" : "ok"; }
+function bar(v) { return `<span class="bar2"><span style="width:${pct(v)}%"></span></span>`; }
+
+function renderState(st) {
+  $("simStatus").textContent = st.status;
+  $("simStatus").className = "status " + st.status;
+  $("vaultTime").textContent = (st.vault_time || "").replace("T", " ").slice(0, 16);
+  $("vaultName").textContent = st.vault_designation || "";
+
+  const p = st.population || {};
+  $("popCard").innerHTML =
+    kv("Active", `${p.active} / ${p.capacity} (${(p.load_pct || 0).toFixed(0)}%)`) +
+    kv("Births / Deaths", `${p.births} / ${p.deaths}`) +
+    kv("Quarantine", p.quarantined) +
+    kv("Average age", (p.average_age || 0).toFixed(1));
+
+  const pw = st.power || {};
+  const balCls = pw.balance_kw < 0 ? "crit" : (pw.reserve_pct < 10 ? "warn" : "ok");
+  $("powerCard").innerHTML =
+    kv("Generation", (pw.generation_kw || 0).toFixed(0) + " kW") +
+    kv("Consumption", (pw.consumption_kw || 0).toFixed(0) + " kW") +
+    `<div class="kv"><span class="k">Balance</span><span class="${balCls}">${(pw.balance_kw||0).toFixed(0)} kW (${(pw.reserve_pct||0).toFixed(0)}%)</span></div>`;
+
+  const sy = st.systems || {};
+  $("sysSummary").innerHTML =
+    kv("Operational", sy.operational) + kv("Degraded", sy.degraded) +
+    kv("Failed", sy.failed) + kv("Avg efficiency", (sy.avg_efficiency || 0).toFixed(0) + "%") +
+    kv("Overdue PM", sy.overdue_maintenance);
+
+  $("resCard").innerHTML = (st.resources || []).filter((r) => r.daily_use > 0).map((r) =>
+    `<div class="kv"><span class="k">${esc(r.label)}</span><span class="${statusClass(r.status)}">${r.runway_days < 0 ? "∞" : r.runway_days + "d"} (${r.status})</span></div>`
+  ).join("") || '<span class="hint">No metered consumption yet.</span>';
+
+  $("alertsCard").innerHTML = (st.alerts || []).length === 0
+    ? '<span class="ok">✓ No active alerts — all systems nominal</span>'
+    : st.alerts.map((a) => `<div class="ev"><span class="${a.level === "CRITICAL" ? "crit" : "warn"}">[${a.level}]</span> ${esc(a.message)}${a.acknowledged ? ' <span class="hint">[ack]</span>' : ''}</div>`).join("");
+
+  $("simInfo").innerHTML =
+    kv("Status", st.status) + kv("Time scale", (st.time_scale || 0) + "×") +
+    kv("Vault time", (st.vault_time || "").replace("T", " ").slice(0, 16)) +
+    kv("Elapsed", `${st.elapsed_years}y ${st.elapsed_days % 365}d`) +
+    kv("Ticks", st.tick_count);
+  $("scaleSel").value = String(st.time_scale);
+
+  const tb = document.querySelector("#sysTable tbody");
+  tb.innerHTML = (st.system_list || []).map((s) => {
+    const cls = s.efficiency < 50 ? "crit" : s.efficiency < 80 ? "warn" : "ok";
+    return `<tr><td>${esc(s.code)}</td><td>${esc(s.name)}</td><td>${esc(s.category)}</td>
+      <td class="${cls}">${esc(s.status)}</td><td>${bar(s.efficiency)} ${(s.efficiency||0).toFixed(0)}%</td></tr>`;
+  }).join("");
+}
+
+function kv(k, v) { return `<div class="kv"><span class="k">${esc(k)}</span><span>${esc(v)}</span></div>`; }
+
+function connectStream() {
+  const es = new EventSource("/api/v1/stream");
+  es.addEventListener("state", (e) => { try { renderState(JSON.parse(e.data)); } catch (_) {} });
+  es.onopen = () => { $("conn").className = "conn on"; $("conn").textContent = "LIVE"; };
+  es.onerror = () => { $("conn").className = "conn off"; $("conn").textContent = "RECONNECTING"; };
+}
+
+// ---- Events ----
+async function refreshEvents() {
+  try {
+    const r = await fetch("/api/v1/events?limit=80");
+    const evs = await r.json();
+    $("eventList").innerHTML = (evs || []).map((e) => {
+      const cls = e.severity === "CRITICAL" ? "crit" : e.severity === "WARNING" ? "warn" : "";
+      return `<div class="ev"><span class="t">${(e.vault_time||"").replace("T"," ").slice(5,16)}</span><span class="c">${esc(e.category)}</span><span class="${cls}">${esc(e.summary)}</span></div>`;
+    }).join("") || '<span class="hint">No events yet.</span>';
+  } catch (_) {}
+}
+
+// ---- Clients / remote ops ----
+async function refreshClients() {
+  try {
+    const r = await fetch("/api/v1/clients", { headers: authHeaders() });
+    if (!r.ok) { document.querySelector("#cliTable tbody").innerHTML = `<tr><td colspan="7" class="warn">Operator token required to view terminals.</td></tr>`; return; }
+    const cs = await r.json();
+    const tb = document.querySelector("#cliTable tbody");
+    tb.innerHTML = (cs || []).map((c) => {
+      const state = c.online ? '<span class="ok">ONLINE</span>' : '<span class="crit">OFFLINE</span>';
+      const ops = `
+        <button onclick="op('${c.id}','SWITCH_VIEW')">VIEW</button>
+        <button onclick="op('${c.id}','IDENTIFY')">IDENTIFY</button>
+        <button onclick="op('${c.id}','SET_KIOSK')">KIOSK</button>
+        <button onclick="op('${c.id}','MESSAGE')">MSG</button>
+        <button onclick="op('${c.id}','REBOOT')">REBOOT</button>`;
+      return `<tr><td>${esc(c.name)}</td><td>${esc(c.kind)}</td><td>${state}</td>
+        <td>${esc((c.telemetry||{}).current_view||"—")}</td><td>${esc(c.address)}</td>
+        <td>${(c.last_seen||"").replace("T"," ").slice(11,19)}</td><td>${ops}</td></tr>`;
+    }).join("") || `<tr><td colspan="7" class="hint">No terminals connected.</td></tr>`;
+  } catch (_) {}
+}
+
+window.op = async function (id, type) {
+  const args = {};
+  if (type === "SWITCH_VIEW") { const v = prompt("View (dashboard, population, resources, facilities, simulation, security):", "dashboard"); if (!v) return; args.view = v; }
+  if (type === "MESSAGE") { const t = prompt("Message to display:"); if (!t) return; args.text = t; }
+  if (type === "SET_KIOSK") { args.enabled = confirm("Enable kiosk mode? OK = enable, Cancel = disable") ? "true" : "false"; }
+  try { await post(`/api/v1/clients/${id}/command`, { type, args }); setMsg(`Queued ${type} for terminal.`); refreshClients(); }
+  catch (e) { setMsg(e.message, true); }
+};
+
+// ---- Boot ----
+connectStream();
+refreshEvents();
+setInterval(() => {
+  if ($("clients").classList.contains("active")) refreshClients();
+  if ($("events").classList.contains("active")) refreshEvents();
+}, (cfg.heartbeat || 5) * 1000);

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -1,0 +1,99 @@
+:root {
+  --green: #00ff66;
+  --green-dim: #00aa44;
+  --green-deep: #064;
+  --amber: #ffaa00;
+  --red: #ff4444;
+  --bg: #020a05;
+  --panel: #04140a;
+  --line: #0b3;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background:
+    repeating-linear-gradient(0deg, rgba(0,40,0,0.10) 0, rgba(0,40,0,0.10) 1px, transparent 1px, transparent 3px),
+    var(--bg);
+  color: var(--green);
+  font-family: "Courier New", ui-monospace, monospace;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.bar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 8px 14px; background: var(--panel);
+  border-bottom: 1px solid var(--green-deep);
+  text-shadow: 0 0 6px rgba(0,255,102,0.4);
+}
+.bar.foot { border-bottom: none; border-top: 1px solid var(--green-deep); font-size: 12px; color: var(--green-dim); }
+.brand .logo { margin-right: 8px; }
+.brand .title { font-weight: bold; letter-spacing: 1px; }
+.ident .sep { color: var(--green-deep); margin: 0 8px; }
+.status { font-weight: bold; }
+.status.RUNNING { color: var(--green); }
+.status.PAUSED { color: var(--amber); }
+.status.STOPPED { color: var(--green-dim); }
+
+.tokenbar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 14px; border-bottom: 1px solid var(--green-deep); font-size: 12px;
+}
+.tokenbar input {
+  background: #021; color: var(--green); border: 1px solid var(--green-deep);
+  padding: 4px 8px; font-family: inherit; width: 260px;
+}
+.conn { margin-left: auto; padding: 2px 8px; border: 1px solid; font-weight: bold; }
+.conn.on { color: var(--green); border-color: var(--green); }
+.conn.off { color: var(--red); border-color: var(--red); }
+
+.tabs { display: flex; gap: 2px; padding: 8px 14px 0; }
+.tab {
+  background: var(--panel); color: var(--green-dim);
+  border: 1px solid var(--green-deep); border-bottom: none;
+  padding: 6px 16px; cursor: pointer; font-family: inherit; letter-spacing: 1px;
+}
+.tab.active { color: var(--green); background: #052; }
+
+main { padding: 14px; }
+.panel { display: none; }
+.panel.active { display: block; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; }
+.card {
+  background: var(--panel); border: 1px solid var(--green-deep);
+  padding: 12px 14px; box-shadow: inset 0 0 24px rgba(0,80,30,0.15);
+}
+.card.wide { grid-column: 1 / -1; }
+.card h2 { margin: 0 0 8px; font-size: 13px; letter-spacing: 2px; color: var(--green); border-bottom: 1px solid var(--green-deep); padding-bottom: 4px; }
+
+button {
+  background: #043; color: var(--green); border: 1px solid var(--green);
+  padding: 6px 12px; cursor: pointer; font-family: inherit; letter-spacing: 1px;
+}
+button:hover { background: #065; box-shadow: 0 0 8px rgba(0,255,102,0.4); }
+select { background: #021; color: var(--green); border: 1px solid var(--green-deep); padding: 4px; font-family: inherit; }
+
+.controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 10px 0; }
+.msg { min-height: 18px; color: var(--amber); }
+.hint { color: var(--green-dim); font-size: 12px; }
+
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid #052; font-size: 13px; }
+th { color: var(--green-dim); letter-spacing: 1px; }
+
+.bar2 { display: inline-block; height: 10px; background: #052; width: 120px; vertical-align: middle; border: 1px solid var(--green-deep); }
+.bar2 > span { display: block; height: 100%; background: var(--green); }
+
+.kv { display: flex; justify-content: space-between; padding: 2px 0; }
+.kv .k { color: var(--green-dim); }
+
+.ok { color: var(--green); }
+.warn { color: var(--amber); }
+.crit { color: var(--red); font-weight: bold; }
+
+.ev { padding: 3px 0; border-bottom: 1px solid #042; }
+.ev .t { color: var(--green-dim); margin-right: 8px; }
+.ev .c { color: var(--green-dim); display: inline-block; width: 96px; }

--- a/internal/simulation/alerts.go
+++ b/internal/simulation/alerts.go
@@ -1,0 +1,95 @@
+package simulation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// minimumViablePopulation is the genetic-diversity floor below which long-term
+// vault viability is at risk.
+const minimumViablePopulation = 160
+
+// evaluateAlerts derives the current set of actionable operational alerts from
+// the snapshot. Acknowledgement state and original raise times are preserved for
+// conditions that persist across cycles.
+func (e *Engine) evaluateAlerts(st protocol.VaultState, prev []protocol.Alert) []protocol.Alert {
+	prevByCode := make(map[string]protocol.Alert, len(prev))
+	for _, a := range prev {
+		prevByCode[a.Code] = a
+	}
+
+	var alerts []protocol.Alert
+	add := func(code string, level protocol.AlertLevel, subsystem, msg string) {
+		a := protocol.Alert{
+			Code: code, Level: level, Subsystem: subsystem, Message: msg,
+			Raised: time.Now().UTC(),
+		}
+		if old, ok := prevByCode[code]; ok {
+			a.Raised = old.Raised
+			a.Acknowledged = old.Acknowledged
+		}
+		alerts = append(alerts, a)
+	}
+
+	// Power.
+	if st.Power.BalanceKW < 0 {
+		add("POWER_DEFICIT", protocol.AlertCritical, "POWER",
+			fmt.Sprintf("Power deficit: drawing %.0f kW against %.0f kW generation",
+				st.Power.ConsumptionKW, st.Power.GenerationKW))
+	} else if st.Power.ReservePct < 10 && st.Power.GenerationKW > 0 {
+		add("POWER_RESERVE_LOW", protocol.AlertWarning, "POWER",
+			fmt.Sprintf("Power reserve low: %.0f%% margin", st.Power.ReservePct))
+	}
+
+	// Facility systems.
+	if st.Systems.Failed > 0 {
+		add("SYSTEM_FAILURES", protocol.AlertCritical, "FACILITIES",
+			fmt.Sprintf("%d system(s) failed and awaiting corrective maintenance", st.Systems.Failed))
+	}
+	for _, s := range st.SystemList {
+		if s.Critical && (s.Status == string(models.SystemStatusFailed) || s.Status == string(models.SystemStatusOffline)) {
+			add("CRIT_SYS_"+s.Code, protocol.AlertCritical, s.Category,
+				fmt.Sprintf("Critical system %s (%s) is %s", s.Name, s.Code, s.Status))
+		}
+	}
+	if st.Systems.Degraded > 0 {
+		add("SYSTEMS_DEGRADED", protocol.AlertWarning, "FACILITIES",
+			fmt.Sprintf("%d system(s) operating in a degraded state", st.Systems.Degraded))
+	}
+	if st.Systems.OverdueMaint > 0 {
+		add("MAINTENANCE_OVERDUE", protocol.AlertWarning, "FACILITIES",
+			fmt.Sprintf("%d system(s) overdue for preventive maintenance", st.Systems.OverdueMaint))
+	}
+
+	// Resources.
+	for _, r := range st.Resources {
+		switch r.Status {
+		case "CRITICAL":
+			add("RES_"+r.Category+"_CRIT", protocol.AlertCritical, "RESOURCES",
+				fmt.Sprintf("%s critical: %d day(s) of runway remaining", r.Label, r.RunwayDays))
+		case "WARNING":
+			add("RES_"+r.Category+"_WARN", protocol.AlertWarning, "RESOURCES",
+				fmt.Sprintf("%s low: %d day(s) of runway remaining", r.Label, r.RunwayDays))
+		}
+	}
+
+	// Population.
+	if st.Population.Active > 0 && st.Population.Active < minimumViablePopulation {
+		add("POP_VIABILITY", protocol.AlertCritical, "POPULATION",
+			fmt.Sprintf("Population %d below minimum viable threshold of %d",
+				st.Population.Active, minimumViablePopulation))
+	}
+	if st.Population.LoadPct > 100 {
+		add("POP_OVERCROWDING", protocol.AlertWarning, "POPULATION",
+			fmt.Sprintf("Population at %.0f%% of designed capacity", st.Population.LoadPct))
+	}
+	if st.Population.Quarantined >= 5 {
+		add("MED_OUTBREAK", protocol.AlertWarning, "MEDICAL",
+			fmt.Sprintf("%d resident(s) in medical quarantine", st.Population.Quarantined))
+	}
+
+	return alerts
+}

--- a/internal/simulation/consumption.go
+++ b/internal/simulation/consumption.go
@@ -1,0 +1,267 @@
+package simulation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/services/resources"
+)
+
+// defaultFoodCaloriesPerUnit is used when a food item does not declare a
+// calorie density, so consumption accounting can still proceed.
+const defaultFoodCaloriesPerUnit = 1500.0 // kcal per kg, ration-pack baseline
+
+// consumeDailyResources draws one day of consumption from inventory based on the
+// vault's household ration requirements. Water is metered in litres and food in
+// calories (converted to mass via each item's calorie density). A shortfall —
+// inventory unable to meet demand — is a reportable operational condition.
+func (e *Engine) consumeDailyResources(ctx context.Context, asOf time.Time) {
+	reqs, err := e.res.GetVaultDailyRequirements(ctx)
+	if err != nil {
+		e.log.Warn("computing daily requirements failed", "error", err)
+		return
+	}
+
+	waterVar := e.variance(e.cfg.Simulation.Consumption.WaterVariance)
+	calVar := e.variance(e.cfg.Simulation.Consumption.CalorieVariance)
+
+	waterDemand := reqs.TotalWaterL * waterVar
+	calorieDemand := reqs.TotalCalories * calVar
+
+	waterUsed, waterShort := e.consumeByQuantity(ctx, "WATER", waterDemand, "Daily potable water draw")
+	foodKg, calShort := e.consumeFoodByCalories(ctx, calorieDemand, "Daily ration distribution")
+
+	// Modest medical/consumable draw proportional to population keeps clinical
+	// stocks moving so runway forecasting stays meaningful.
+	medDemand := float64(e.state.Population.Active) * 0.02
+	medUsed, _ := e.consumeByQuantity(ctx, "MEDICAL", medDemand, "Routine clinical consumption")
+
+	e.mu.Lock()
+	e.dailyUse["WATER"] = waterDemand
+	e.dailyUse["FOOD"] = foodKg
+	e.dailyUse["MEDICAL"] = medUsed
+	_ = waterUsed
+	e.mu.Unlock()
+
+	if waterShort > 0.5 {
+		e.emitEvent(ctx, asOf, catResource, "WATER_SHORTFALL", protocol.AlertCritical,
+			"Potable water shortfall",
+			fmt.Sprintf("Demand exceeded supply by %.0f L; rationing recommended.", waterShort))
+	}
+	if calShort > 1000 {
+		e.emitEvent(ctx, asOf, catResource, "FOOD_SHORTFALL", protocol.AlertCritical,
+			"Ration shortfall",
+			fmt.Sprintf("Caloric demand exceeded supply by %.0f kcal; ration class review required.", calShort))
+	}
+}
+
+// consumeByQuantity consumes the requested quantity (in the category's unit)
+// across the available items of a category, oldest stock first. It returns the
+// amount actually consumed and any unmet shortfall.
+func (e *Engine) consumeByQuantity(ctx context.Context, categoryCode string, demand float64, reason string) (consumed, shortfall float64) {
+	if demand <= 0 {
+		return 0, 0
+	}
+	cat, err := e.res.GetCategoryByCode(ctx, categoryCode)
+	if err != nil || cat == nil {
+		return 0, demand
+	}
+	items, err := e.res.ListItems(ctx, cat.ID, models.Pagination{Page: 1, PageSize: 100})
+	if err != nil {
+		return 0, demand
+	}
+
+	remaining := demand
+	for _, item := range items.Items {
+		if remaining <= 0 {
+			break
+		}
+		avail := e.availableForItem(ctx, item.ID)
+		if avail <= 0 {
+			continue
+		}
+		take := remaining
+		if take > avail {
+			take = avail
+		}
+		if err := e.res.RecordConsumption(ctx, resources.ConsumptionInput{
+			ItemID:            item.ID,
+			Quantity:          take,
+			Reason:            reason,
+			RelatedEntityType: "VAULT",
+		}); err != nil {
+			continue
+		}
+		remaining -= take
+		consumed += take
+	}
+	if remaining > 0 {
+		shortfall = remaining
+	}
+	return consumed, shortfall
+}
+
+// consumeFoodByCalories converts a caloric demand into mass drawn from food
+// stocks using each item's calorie density. It returns the kilograms consumed
+// and any unmet caloric shortfall.
+func (e *Engine) consumeFoodByCalories(ctx context.Context, calorieDemand float64, reason string) (kg, calorieShortfall float64) {
+	if calorieDemand <= 0 {
+		return 0, 0
+	}
+	cat, err := e.res.GetCategoryByCode(ctx, "FOOD")
+	if err != nil || cat == nil {
+		return 0, calorieDemand
+	}
+	items, err := e.res.ListItems(ctx, cat.ID, models.Pagination{Page: 1, PageSize: 100})
+	if err != nil {
+		return 0, calorieDemand
+	}
+
+	remainingCal := calorieDemand
+	for _, item := range items.Items {
+		if remainingCal <= 0 {
+			break
+		}
+		density := defaultFoodCaloriesPerUnit
+		if item.CaloriesPerUnit != nil && *item.CaloriesPerUnit > 0 {
+			density = *item.CaloriesPerUnit
+		}
+		avail := e.availableForItem(ctx, item.ID)
+		if avail <= 0 {
+			continue
+		}
+		neededUnits := remainingCal / density
+		take := neededUnits
+		if take > avail {
+			take = avail
+		}
+		if err := e.res.RecordConsumption(ctx, resources.ConsumptionInput{
+			ItemID:            item.ID,
+			Quantity:          take,
+			Reason:            reason,
+			RelatedEntityType: "VAULT",
+		}); err != nil {
+			continue
+		}
+		kg += take
+		remainingCal -= take * density
+	}
+	if remainingCal > 0 {
+		calorieShortfall = remainingCal
+	}
+	return kg, calorieShortfall
+}
+
+// processExpirations marks perishable stock that has passed its expiration date
+// as spoiled and reports a notable spoilage batch to the operational log.
+func (e *Engine) processExpirations(ctx context.Context, asOf time.Time) {
+	count, err := e.res.ProcessExpiredItems(ctx, asOf)
+	if err != nil {
+		e.log.Debug("processing expirations failed", "error", err)
+		return
+	}
+	if count >= 3 {
+		e.emitEvent(ctx, asOf, catResource, "SPOILAGE", protocol.AlertWarning,
+			"Stock spoilage recorded",
+			fmt.Sprintf("%d stock lot(s) passed expiration and were written off as spoilage.", count))
+	}
+}
+
+// produceDailyResources records one day of internal production for producible
+// items, scaled by the efficiency of the facility category that governs them
+// (hydroponics for food, water treatment for water, and so on).
+func (e *Engine) produceDailyResources(ctx context.Context, asOf time.Time) {
+	cats, err := e.res.ListCategories(ctx)
+	if err != nil {
+		return
+	}
+	catCodeByID := make(map[string]string, len(cats))
+	for _, c := range cats {
+		catCodeByID[c.ID] = c.Code
+	}
+
+	eff := e.systemEfficiencyByCategory(ctx)
+
+	for _, cat := range cats {
+		items, err := e.res.ListItems(ctx, cat.ID, models.Pagination{Page: 1, PageSize: 100})
+		if err != nil {
+			continue
+		}
+		for _, item := range items.Items {
+			if !item.IsProducible || item.ProductionRatePerDay == nil || *item.ProductionRatePerDay <= 0 {
+				continue
+			}
+			factor := productionEfficiency(cat.Code, eff)
+			qty := *item.ProductionRatePerDay * factor
+			if qty <= 0 {
+				continue
+			}
+
+			var expiration *time.Time
+			if item.ShelfLifeDays != nil && *item.ShelfLifeDays > 0 {
+				exp := asOf.AddDate(0, 0, *item.ShelfLifeDays)
+				expiration = &exp
+			}
+			if _, err := e.res.RecordProduction(ctx, resources.ProductionInput{
+				ItemID:          item.ID,
+				Quantity:        qty,
+				StorageLocation: fmt.Sprintf("PROD-%s", safePrefix(cat.Code)),
+				ExpirationDate:  expiration,
+				Reason:          "Daily internal production",
+			}); err != nil {
+				e.log.Debug("recording production failed", "item", item.ItemCode, "error", err)
+			}
+		}
+	}
+}
+
+// productionEfficiency maps a resource category to the facility category whose
+// efficiency gates its production, returning a 0..1 scaling factor.
+func productionEfficiency(resourceCategory string, eff map[string]float64) float64 {
+	var key string
+	switch resourceCategory {
+	case "FOOD":
+		key = string(models.SystemCategoryFoodProduction)
+	case "WATER":
+		key = string(models.SystemCategoryWater)
+	case "POWER":
+		key = string(models.SystemCategoryPower)
+	default:
+		return 1.0
+	}
+	if v, ok := eff[key]; ok {
+		return v
+	}
+	return 1.0
+}
+
+// availableForItem returns the total available (unreserved) quantity on hand for
+// an item across all available stock lots.
+func (e *Engine) availableForItem(ctx context.Context, itemID string) float64 {
+	var total float64
+	const q = `SELECT COALESCE(SUM(quantity - quantity_reserved), 0)
+		FROM resource_stocks WHERE item_id = ? AND status = 'AVAILABLE'`
+	if err := e.db.QueryRowContext(ctx, q, itemID).Scan(&total); err != nil {
+		return 0
+	}
+	return total
+}
+
+// variance returns a multiplicative consumption variance factor in
+// [1-v, 1+v] using the engine's deterministic RNG.
+func (e *Engine) variance(v float64) float64 {
+	if v <= 0 {
+		return 1.0
+	}
+	return 1.0 + (e.rng.Float64()*2-1)*v
+}
+
+func safePrefix(s string) string {
+	if len(s) >= 4 {
+		return s[:4]
+	}
+	return s
+}

--- a/internal/simulation/degradation.go
+++ b/internal/simulation/degradation.go
@@ -1,0 +1,225 @@
+package simulation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+const (
+	// efficiencyDegradedBelow is the threshold under which a system is reported
+	// as degraded rather than fully operational.
+	efficiencyDegradedBelow = 80.0
+	// efficiencyFailedBelow is the threshold under which an unmaintained system
+	// is considered failed.
+	efficiencyFailedBelow = 15.0
+
+	// maintenanceChancePerDay is the daily probability that maintenance crews
+	// service a given overdue system, restoring its condition.
+	maintenanceChancePerDay = 0.34
+	// maintenanceRestore is the efficiency restored by a preventive service.
+	maintenanceRestore = 35.0
+)
+
+// degradeSystems applies one day of wear to every operational facility system,
+// accrues runtime, transitions status across thresholds, and reports notable
+// changes to the operational log.
+func (e *Engine) degradeSystems(ctx context.Context, asOf time.Time) {
+	list, err := e.fac.ListSystems(ctx, models.FacilitySystemFilter{}, models.Pagination{Page: 1, PageSize: 500})
+	if err != nil {
+		e.log.Warn("listing systems for degradation failed", "error", err)
+		return
+	}
+
+	baseDecay := e.cfg.Simulation.Consumption.EfficiencyDecayRate * 100 // percent/day
+	if baseDecay <= 0 {
+		baseDecay = 0.05
+	}
+
+	for _, sys := range list.Systems {
+		if !sys.Status.IsOperational() {
+			continue // offline, failed, destroyed or in maintenance: no wear
+		}
+
+		// Overdue maintenance accelerates wear.
+		wear := 1.0
+		if sys.IsOverdueForMaintenance(asOf) {
+			wear = 2.2
+		}
+		jitter := 0.5 + e.rng.Float64() // 0.5..1.5
+		decay := baseDecay * wear * jitter
+
+		newEff := sys.EfficiencyPercent - decay
+		if newEff < 0 {
+			newEff = 0
+		}
+
+		newStatus := models.SystemStatusOperational
+		switch {
+		case newEff < efficiencyFailedBelow:
+			newStatus = models.SystemStatusFailed
+		case newEff < efficiencyDegradedBelow:
+			newStatus = models.SystemStatusDegraded
+		}
+
+		runtimeAdd := 24.0 * (newEff / 100.0)
+		output := outputFor(sys, newEff)
+
+		if err := e.updateSystemDaily(ctx, sys.ID, newEff, newStatus, sys.TotalRuntimeHours+runtimeAdd, output); err != nil {
+			e.log.Debug("updating system condition failed", "system", sys.SystemCode, "error", err)
+			continue
+		}
+
+		if newStatus != sys.Status {
+			e.reportStatusChange(ctx, asOf, sys, newStatus, newEff)
+		}
+	}
+}
+
+// reportStatusChange emits an operational event when a system crosses a status
+// threshold downward.
+func (e *Engine) reportStatusChange(ctx context.Context, asOf time.Time, sys *models.FacilitySystem, newStatus models.SystemStatus, eff float64) {
+	switch newStatus {
+	case models.SystemStatusFailed:
+		e.emitEvent(ctx, asOf, catFacility, "SYSTEM_FAILURE", protocol.AlertCritical,
+			fmt.Sprintf("%s failed", sys.Name),
+			fmt.Sprintf("%s (%s) dropped to %.0f%% efficiency and is offline pending corrective maintenance.",
+				sys.Name, sys.SystemCode, eff))
+	case models.SystemStatusDegraded:
+		e.emitEvent(ctx, asOf, catFacility, "SYSTEM_DEGRADED", protocol.AlertWarning,
+			fmt.Sprintf("%s degraded", sys.Name),
+			fmt.Sprintf("%s (%s) efficiency fell to %.0f%%; preventive maintenance advised.",
+				sys.Name, sys.SystemCode, eff))
+	}
+}
+
+// maintenanceSweep services overdue systems with some daily probability,
+// restoring condition, consuming spare parts, and recording the work.
+func (e *Engine) maintenanceSweep(ctx context.Context, asOf time.Time) {
+	list, err := e.fac.ListSystems(ctx, models.FacilitySystemFilter{}, models.Pagination{Page: 1, PageSize: 500})
+	if err != nil {
+		return
+	}
+	for _, sys := range list.Systems {
+		needsService := sys.IsOverdueForMaintenance(asOf) ||
+			sys.Status == models.SystemStatusFailed ||
+			sys.EfficiencyPercent < efficiencyDegradedBelow
+		if !needsService {
+			continue
+		}
+		// Failed systems are always prioritised; others are scheduled.
+		chance := maintenanceChancePerDay
+		if sys.Status == models.SystemStatusFailed {
+			chance = 0.6
+		}
+		if e.rng.Float64() > chance {
+			continue
+		}
+		e.performMaintenance(ctx, asOf, sys)
+	}
+}
+
+// performMaintenance restores a system, consumes parts, and records the work in
+// the maintenance log and operational event feed.
+func (e *Engine) performMaintenance(ctx context.Context, asOf time.Time, sys *models.FacilitySystem) {
+	newEff := sys.EfficiencyPercent + maintenanceRestore
+	if newEff > 100 {
+		newEff = 100
+	}
+	output := outputFor(sys, newEff)
+
+	if err := e.updateSystemServiced(ctx, sys.ID, newEff, output, asOf, sys.MaintenanceIntervalDays); err != nil {
+		e.log.Debug("recording maintenance failed", "system", sys.SystemCode, "error", err)
+		return
+	}
+
+	// Spare parts are drawn from inventory to reflect real material cost.
+	e.consumeByQuantity(ctx, "PARTS", 1.0, fmt.Sprintf("Maintenance of %s", sys.SystemCode))
+
+	mtype := models.MaintenanceTypePreventive
+	if sys.Status == models.SystemStatusFailed {
+		mtype = models.MaintenanceTypeCorrective
+	}
+	e.insertMaintenanceRecord(ctx, asOf, sys, mtype, newEff)
+
+	e.emitEvent(ctx, asOf, catFacility, "MAINTENANCE_COMPLETED", protocol.AlertInfo,
+		fmt.Sprintf("%s serviced", sys.Name),
+		fmt.Sprintf("%s maintenance on %s (%s) restored efficiency to %.0f%%.",
+			mtype, sys.Name, sys.SystemCode, newEff))
+}
+
+// updateSystemDaily writes a system's condition after one day of wear.
+func (e *Engine) updateSystemDaily(ctx context.Context, id string, eff float64, status models.SystemStatus, runtime, output float64) error {
+	const q = `UPDATE facility_systems
+		SET efficiency_percent = ?, status = ?, total_runtime_hours = ?, current_output = ?, updated_at = ?
+		WHERE id = ?`
+	_, err := e.db.ExecContext(ctx, q, eff, string(status), runtime, output,
+		time.Now().UTC().Format(time.RFC3339), id)
+	return err
+}
+
+// updateSystemServiced writes a system's condition after maintenance.
+func (e *Engine) updateSystemServiced(ctx context.Context, id string, eff, output float64, asOf time.Time, intervalDays int) error {
+	next := asOf.AddDate(0, 0, intervalDays)
+	const q = `UPDATE facility_systems
+		SET efficiency_percent = ?, status = 'OPERATIONAL', current_output = ?,
+		    last_maintenance_date = ?, next_maintenance_due = ?, updated_at = ?
+		WHERE id = ?`
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := e.db.ExecContext(ctx, q, eff, output,
+		asOf.UTC().Format(time.RFC3339), next.UTC().Format(time.RFC3339), now, id)
+	return err
+}
+
+// insertMaintenanceRecord records completed maintenance work.
+func (e *Engine) insertMaintenanceRecord(ctx context.Context, asOf time.Time, sys *models.FacilitySystem, mtype models.MaintenanceType, effAfter float64) {
+	const q = `INSERT INTO maintenance_records
+		(id, system_id, maintenance_type, description, completed_at, outcome,
+		 system_status_before, system_status_after, efficiency_before, efficiency_after,
+		 created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, 'COMPLETED', ?, 'OPERATIONAL', ?, ?, ?, ?)`
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := e.db.ExecContext(ctx, q,
+		e.idGen.NewID(), sys.ID, string(mtype),
+		fmt.Sprintf("Scheduled %s maintenance", mtype),
+		asOf.UTC().Format(time.RFC3339),
+		string(sys.Status), sys.EfficiencyPercent, effAfter, now, now)
+	if err != nil {
+		e.log.Debug("inserting maintenance record failed", "error", err)
+	}
+}
+
+// outputFor estimates a system's current output from its rated capacity and
+// present efficiency.
+func outputFor(sys *models.FacilitySystem, eff float64) float64 {
+	if sys.CapacityRating == nil {
+		return 0
+	}
+	return *sys.CapacityRating * (eff / 100.0)
+}
+
+// systemEfficiencyByCategory returns the average efficiency (0..1) of
+// operational systems grouped by facility category.
+func (e *Engine) systemEfficiencyByCategory(ctx context.Context) map[string]float64 {
+	out := make(map[string]float64)
+	const q = `SELECT category, AVG(efficiency_percent)
+		FROM facility_systems
+		WHERE status IN ('OPERATIONAL','DEGRADED')
+		GROUP BY category`
+	rows, err := e.db.QueryContext(ctx, q)
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cat string
+		var avg float64
+		if err := rows.Scan(&cat, &avg); err == nil {
+			out[cat] = avg / 100.0
+		}
+	}
+	return out
+}

--- a/internal/simulation/demographics.go
+++ b/internal/simulation/demographics.go
@@ -1,0 +1,135 @@
+package simulation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/services/population"
+)
+
+const (
+	// annualBirthRate and annualDeathRate are crude vault-wide vital rates used
+	// to derive daily probabilities. They are intentionally conservative.
+	annualBirthRate = 0.014
+	annualDeathRate = 0.009
+)
+
+var newbornGivenNames = []string{
+	"Alex", "Sam", "Jordan", "Casey", "Riley", "Morgan", "Quinn", "Avery",
+	"Reese", "Drew", "Parker", "Rowan", "Sage", "Emerson", "Hollis", "Marlow",
+}
+
+var deathCauses = []string{
+	"Natural causes", "Cardiac event", "Respiratory failure",
+	"Complications of chronic illness", "Industrial accident",
+}
+
+// processDemographics applies one day of vital statistics: a small daily
+// probability of a birth and of a death, each routed through the population
+// service so registries, lineage and counts stay consistent.
+func (e *Engine) processDemographics(ctx context.Context, asOf time.Time) {
+	var active int
+	if err := e.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM residents WHERE status = 'ACTIVE'`).Scan(&active); err != nil || active <= 0 {
+		return
+	}
+
+	if e.rng.Float64() < float64(active)*annualDeathRate/365.0 {
+		e.registerNaturalDeath(ctx, asOf)
+	}
+	if e.rng.Float64() < float64(active)*annualBirthRate/365.0 {
+		e.registerVaultBirth(ctx, asOf)
+	}
+}
+
+// registerNaturalDeath records the death of a randomly selected active resident.
+func (e *Engine) registerNaturalDeath(ctx context.Context, asOf time.Time) {
+	var id, name string
+	const q = `SELECT id, surname || ', ' || given_names FROM residents
+		WHERE status = 'ACTIVE' LIMIT 1 OFFSET ?`
+	offset := e.randomOffset(ctx, "SELECT COUNT(*) FROM residents WHERE status='ACTIVE'")
+	if offset < 0 {
+		return
+	}
+	if err := e.db.QueryRowContext(ctx, q, offset).Scan(&id, &name); err != nil {
+		return
+	}
+	cause := deathCauses[e.rng.Intn(len(deathCauses))]
+	if err := e.pop.RegisterDeath(ctx, id, population.DeathRegistration{
+		DateOfDeath: asOf,
+		Cause:       cause,
+	}); err != nil {
+		e.log.Debug("registering death failed", "error", err)
+		return
+	}
+	e.mu.Lock()
+	e.deaths++
+	e.mu.Unlock()
+	e.emitEvent(ctx, asOf, catPopulation, "DEATH", protocol.AlertInfo,
+		fmt.Sprintf("Death recorded: %s", name),
+		fmt.Sprintf("%s passed away (%s). Vital record filed.", name, cause))
+}
+
+// registerVaultBirth records a birth when a viable parental pairing exists.
+func (e *Engine) registerVaultBirth(ctx context.Context, asOf time.Time) {
+	adultCutoff := asOf.AddDate(-18, 0, 0).Format(time.RFC3339)
+	fertileFloor := asOf.AddDate(-45, 0, 0).Format(time.RFC3339)
+
+	// Choose an active adult mother of child-bearing age who shares a household.
+	var motherID, householdID, surname string
+	const motherQ = `SELECT id, household_id, surname FROM residents
+		WHERE status = 'ACTIVE' AND sex = 'F' AND household_id IS NOT NULL
+		  AND date_of_birth <= ? AND date_of_birth >= ?
+		LIMIT 1 OFFSET ?`
+	countQ := fmt.Sprintf(`SELECT COUNT(*) FROM residents
+		WHERE status='ACTIVE' AND sex='F' AND household_id IS NOT NULL
+		  AND date_of_birth <= '%s' AND date_of_birth >= '%s'`, adultCutoff, fertileFloor)
+	offset := e.randomOffset(ctx, countQ)
+	if offset < 0 {
+		return
+	}
+	if err := e.db.QueryRowContext(ctx, motherQ, adultCutoff, fertileFloor, offset).
+		Scan(&motherID, &householdID, &surname); err != nil {
+		return
+	}
+
+	// Require an adult father in the same household.
+	var fatherID string
+	const fatherQ = `SELECT id FROM residents
+		WHERE status = 'ACTIVE' AND sex = 'M' AND household_id = ? AND date_of_birth <= ?
+		LIMIT 1`
+	if err := e.db.QueryRowContext(ctx, fatherQ, householdID, adultCutoff).Scan(&fatherID); err != nil {
+		return // no eligible pairing; skip this birth opportunity
+	}
+
+	sex := models.SexFemale
+	if e.rng.Float64() < 0.5 {
+		sex = models.SexMale
+	}
+	given := newbornGivenNames[e.rng.Intn(len(newbornGivenNames))]
+
+	child, err := e.pop.RegisterBirth(ctx, population.BirthRegistration{
+		Surname:     surname,
+		GivenNames:  given,
+		DateOfBirth: asOf,
+		Sex:         sex,
+		Parent1ID:   fatherID,
+		Parent2ID:   motherID,
+		HouseholdID: householdID,
+		Notes:       "Registered by simulation control core",
+	})
+	if err != nil {
+		e.log.Debug("registering birth failed", "error", err)
+		return
+	}
+	e.mu.Lock()
+	e.births++
+	e.mu.Unlock()
+	e.emitEvent(ctx, asOf, catPopulation, "BIRTH", protocol.AlertInfo,
+		fmt.Sprintf("Birth registered: %s, %s", surname, given),
+		fmt.Sprintf("A child (%s) was born to household %s. Registry number %s assigned.",
+			sex.String(), householdID, child.RegistryNumber))
+}

--- a/internal/simulation/demographics.go
+++ b/internal/simulation/demographics.go
@@ -75,8 +75,10 @@ func (e *Engine) registerNaturalDeath(ctx context.Context, asOf time.Time) {
 
 // registerVaultBirth records a birth when a viable parental pairing exists.
 func (e *Engine) registerVaultBirth(ctx context.Context, asOf time.Time) {
-	adultCutoff := asOf.AddDate(-18, 0, 0).Format(time.RFC3339)
-	fertileFloor := asOf.AddDate(-45, 0, 0).Format(time.RFC3339)
+	// date_of_birth is stored as a DATE ('YYYY-MM-DD'); compare against the same
+	// format so SQLite's comparison and any date functions behave correctly.
+	adultCutoff := asOf.AddDate(-18, 0, 0).Format(time.DateOnly)
+	fertileFloor := asOf.AddDate(-45, 0, 0).Format(time.DateOnly)
 
 	// Choose an active adult mother of child-bearing age who shares a household.
 	var motherID, householdID, surname string
@@ -84,10 +86,10 @@ func (e *Engine) registerVaultBirth(ctx context.Context, asOf time.Time) {
 		WHERE status = 'ACTIVE' AND sex = 'F' AND household_id IS NOT NULL
 		  AND date_of_birth <= ? AND date_of_birth >= ?
 		LIMIT 1 OFFSET ?`
-	countQ := fmt.Sprintf(`SELECT COUNT(*) FROM residents
+	const countQ = `SELECT COUNT(*) FROM residents
 		WHERE status='ACTIVE' AND sex='F' AND household_id IS NOT NULL
-		  AND date_of_birth <= '%s' AND date_of_birth >= '%s'`, adultCutoff, fertileFloor)
-	offset := e.randomOffset(ctx, countQ)
+		  AND date_of_birth <= ? AND date_of_birth >= ?`
+	offset := e.randomOffset(ctx, countQ, adultCutoff, fertileFloor)
 	if offset < 0 {
 		return
 	}

--- a/internal/simulation/engine.go
+++ b/internal/simulation/engine.go
@@ -1,0 +1,426 @@
+// Package simulation implements the VT-UOS simulation control core: the
+// authoritative engine that advances vault time and drives realistic resource
+// consumption, production, facility degradation, scheduled maintenance, and
+// operational incidents against the persistent database.
+//
+// The engine is designed as operational software, not a game. Every interval it
+// processes is deterministic given its seed, mutates real domain state through
+// the service layer, records occurrences to the persistent event and audit
+// logs, and publishes an operational snapshot (protocol.VaultState) to any
+// subscribed consumers — the local TUI, the master server's web console, and
+// remote client terminals.
+package simulation
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/config"
+	"github.com/vtuos/vtuos/internal/database"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/services/facilities"
+	"github.com/vtuos/vtuos/internal/services/population"
+	"github.com/vtuos/vtuos/internal/services/resources"
+	"github.com/vtuos/vtuos/internal/util"
+)
+
+const (
+	// wakeInterval is how often the engine wakes to advance simulated time.
+	// A short real-time cadence keeps telemetry fresh for exhibit displays.
+	wakeInterval = 1 * time.Second
+
+	// maxHoursPerWake caps the simulated hours processed per wake so a large
+	// time scale (or a long pause/resume gap) cannot stall the engine.
+	maxHoursPerWake = 168 // one simulated week
+
+	// eventBufferSize is the number of recent operational events retained in
+	// memory for the live feed. The full history lives in simulation_events.
+	eventBufferSize = 200
+)
+
+// Engine is the simulation control core. It is safe for concurrent use.
+type Engine struct {
+	db    *database.DB
+	cfg   *config.Config
+	clock *util.VaultClock
+	log   *slog.Logger
+	idGen *util.IDGenerator
+
+	// Domain services. The engine owns a single shared set so the TUI and
+	// server read and write through the same code paths the engine uses.
+	pop *population.Service
+	res *resources.Service
+	fac *facilities.Service
+
+	// rng is the engine's deterministic source of randomness. It is only
+	// touched from the processing goroutine (and Step), so it needs no lock.
+	rng  *rand.Rand
+	seed int64
+
+	mu       sync.RWMutex
+	status   protocol.SimStatus
+	lastProc time.Time // last vault time fully processed
+	sealDate time.Time
+	tickN    uint64
+
+	// dailyUse holds the most recently planned daily consumption per resource
+	// category code, used to compute runway in operational snapshots.
+	dailyUse map[string]float64
+
+	// births/deaths accumulate over the run for the census board.
+	births int
+	deaths int
+
+	state  protocol.VaultState
+	alerts []protocol.Alert
+	events []protocol.EventRecord
+
+	subs   map[int]chan protocol.VaultState
+	nextID int
+
+	// lifecycle
+	runMu   sync.Mutex
+	running bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+}
+
+// New constructs a simulation engine bound to the given database, configuration
+// and vault clock. The engine creates its own service layer; callers that need
+// service access (TUI, server) should reuse the accessors below.
+func New(db *database.DB, cfg *config.Config, clock *util.VaultClock) *Engine {
+	seed := deriveSeed(cfg)
+	e := &Engine{
+		db:       db,
+		cfg:      cfg,
+		clock:    clock,
+		log:      slog.Default().With("component", "simulation"),
+		idGen:    util.NewIDGenerator(),
+		pop:      population.NewService(db.DB, cfg.Vault.Number),
+		res:      resources.NewService(db.DB),
+		fac:      facilities.NewService(db.DB),
+		rng:      rand.New(rand.NewSource(seed)),
+		seed:     seed,
+		status:   protocol.SimPaused,
+		dailyUse: make(map[string]float64),
+		subs:     make(map[int]chan protocol.VaultState),
+	}
+	if sd, err := cfg.Simulation.StartDateTime(); err == nil {
+		e.sealDate = sd
+	} else if sd, err := cfg.Vault.SealedDateTime(); err == nil {
+		e.sealDate = sd
+	} else {
+		e.sealDate = clock.Now()
+	}
+	e.lastProc = clock.Now()
+	return e
+}
+
+// deriveSeed produces a stable seed so identical configurations replay
+// identically, satisfying the project's deterministic-build constraint.
+func deriveSeed(cfg *config.Config) int64 {
+	seed := int64(cfg.Vault.Number) * 1_000_003
+	for i, r := range cfg.Simulation.StartDate {
+		seed += int64(r) * int64(i+1)
+	}
+	if seed == 0 {
+		seed = 2077
+	}
+	return seed
+}
+
+// Population returns the engine's population service.
+func (e *Engine) Population() *population.Service { return e.pop }
+
+// Resources returns the engine's resource service.
+func (e *Engine) Resources() *resources.Service { return e.res }
+
+// Facilities returns the engine's facilities service.
+func (e *Engine) Facilities() *facilities.Service { return e.fac }
+
+// Clock returns the vault clock driving the engine.
+func (e *Engine) Clock() *util.VaultClock { return e.clock }
+
+// Start prepares operational state and, if simulation is enabled, begins
+// advancing vault time. It is idempotent: a second call is a no-op.
+func (e *Engine) Start(ctx context.Context) error {
+	e.runMu.Lock()
+	defer e.runMu.Unlock()
+	if e.running {
+		return nil
+	}
+
+	// Restore persisted operational time for power-loss continuity.
+	if err := e.loadState(ctx); err != nil {
+		e.log.Warn("could not restore simulation state", "error", err)
+	}
+
+	// Ensure the vault has infrastructure to operate. Core systems are
+	// reference data that any commissioned vault possesses.
+	if err := EnsureCoreSystems(ctx, e.db, e.fac, e.sealDate); err != nil {
+		e.log.Warn("could not ensure core facility systems", "error", err)
+	}
+
+	// Build an initial operational snapshot so consumers have data immediately.
+	if err := e.recomputeState(ctx); err != nil {
+		e.log.Warn("initial state computation failed", "error", err)
+	}
+
+	enabled := e.cfg.Simulation.Enabled && !e.clock.IsPaused()
+	e.mu.Lock()
+	if enabled {
+		e.status = protocol.SimRunning
+	} else {
+		e.status = protocol.SimPaused
+	}
+	e.mu.Unlock()
+
+	e.stopCh = make(chan struct{})
+	e.doneCh = make(chan struct{})
+	e.running = true
+	go e.run()
+
+	e.log.Info("simulation control core started",
+		"status", e.statusString(),
+		"vault_time", e.clock.Now().Format(time.RFC3339),
+		"time_scale", e.clock.TimeScale(),
+		"seed", e.seed,
+	)
+	return nil
+}
+
+// Stop halts the processing goroutine and persists operational state.
+func (e *Engine) Stop(ctx context.Context) error {
+	e.runMu.Lock()
+	if !e.running {
+		e.runMu.Unlock()
+		return nil
+	}
+	e.running = false
+	close(e.stopCh)
+	done := e.doneCh
+	e.runMu.Unlock()
+
+	<-done
+
+	if err := e.saveState(ctx); err != nil {
+		e.log.Warn("could not persist simulation state on stop", "error", err)
+	}
+	e.log.Info("simulation control core stopped")
+	return nil
+}
+
+// run is the processing loop. It wakes on a fixed real-time cadence and advances
+// the simulation to match the wall-clock-scaled vault time.
+func (e *Engine) run() {
+	defer close(e.doneCh)
+	ticker := time.NewTicker(wakeInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.stopCh:
+			return
+		case <-ticker.C:
+			if e.Status() != protocol.SimRunning {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if err := e.advanceTo(ctx, e.clock.Now()); err != nil {
+				e.log.Error("simulation tick failed", "error", err)
+			}
+			cancel()
+		}
+	}
+}
+
+// Pause holds vault time steady without unloading the engine.
+func (e *Engine) Pause() {
+	e.clock.Pause()
+	e.mu.Lock()
+	e.status = protocol.SimPaused
+	e.mu.Unlock()
+	e.broadcast()
+	e.log.Info("simulation paused", "vault_time", e.clock.Now().Format(time.RFC3339))
+}
+
+// Resume restarts automatic time progression.
+func (e *Engine) Resume() {
+	e.clock.Resume()
+	e.mu.Lock()
+	e.lastProc = e.clock.Now()
+	e.status = protocol.SimRunning
+	e.mu.Unlock()
+	e.broadcast()
+	e.log.Info("simulation resumed", "vault_time", e.clock.Now().Format(time.RFC3339))
+}
+
+// SetTimeScale changes the ratio of vault time to real time. Valid scales are
+// non-negative; a scale of zero effectively freezes progression.
+func (e *Engine) SetTimeScale(scale float64) error {
+	if scale < 0 {
+		return fmt.Errorf("time scale must be non-negative, got %.2f", scale)
+	}
+	e.clock.SetTimeScale(scale)
+	e.mu.Lock()
+	e.lastProc = e.clock.Now()
+	e.mu.Unlock()
+	e.broadcast()
+	e.log.Info("time scale changed", "scale", scale)
+	return nil
+}
+
+// Step manually advances vault time by the given number of hours and processes
+// the interval. It is intended for use while paused (single-stepping the core).
+func (e *Engine) Step(ctx context.Context, hours int) error {
+	if hours <= 0 {
+		hours = 1
+	}
+	if !e.clock.IsPaused() {
+		e.clock.Pause()
+		e.mu.Lock()
+		e.status = protocol.SimPaused
+		e.mu.Unlock()
+	}
+	if err := e.clock.Advance(time.Duration(hours) * time.Hour); err != nil {
+		return fmt.Errorf("advancing clock: %w", err)
+	}
+
+	// A single advanceTo processes at most maxHoursPerWake (runaway protection
+	// for the automatic loop). An explicit step is an operator action, so drain
+	// the full requested span in capped chunks.
+	target := e.clock.Now()
+	for i := 0; i <= hours/maxHoursPerWake+1; i++ {
+		if err := e.advanceTo(ctx, target); err != nil {
+			return err
+		}
+		e.mu.RLock()
+		caughtUp := !e.lastProc.Before(target.Add(-time.Hour))
+		e.mu.RUnlock()
+		if caughtUp {
+			break
+		}
+	}
+	return nil
+}
+
+// Status returns the current run state of the control core.
+func (e *Engine) Status() protocol.SimStatus {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.status
+}
+
+func (e *Engine) statusString() string { return string(e.Status()) }
+
+// Snapshot returns the latest operational snapshot. The returned value is a
+// copy safe for the caller to read and marshal.
+func (e *Engine) Snapshot() protocol.VaultState {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.cloneState()
+}
+
+// Alerts returns the currently active operational alerts.
+func (e *Engine) Alerts() []protocol.Alert {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]protocol.Alert, len(e.alerts))
+	copy(out, e.alerts)
+	return out
+}
+
+// Events returns up to limit of the most recent operational events, newest first.
+func (e *Engine) Events(limit int) []protocol.EventRecord {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if limit <= 0 || limit > len(e.events) {
+		limit = len(e.events)
+	}
+	out := make([]protocol.EventRecord, 0, limit)
+	for i := len(e.events) - 1; i >= 0 && len(out) < limit; i-- {
+		out = append(out, e.events[i])
+	}
+	return out
+}
+
+// AcknowledgeAlert clears the acknowledged flag for the alert with the given code.
+func (e *Engine) AcknowledgeAlert(code string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i := range e.alerts {
+		if e.alerts[i].Code == code {
+			e.alerts[i].Acknowledged = true
+			return true
+		}
+	}
+	return false
+}
+
+// Subscribe registers a consumer for operational snapshots. It returns the
+// subscriber id and a buffered channel that receives a copy of the state after
+// every recomputation. Call Unsubscribe with the id to release it.
+func (e *Engine) Subscribe() (int, <-chan protocol.VaultState) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	id := e.nextID
+	e.nextID++
+	ch := make(chan protocol.VaultState, 4)
+	e.subs[id] = ch
+	// Prime the subscriber with the current state.
+	ch <- e.cloneState()
+	return id, ch
+}
+
+// Unsubscribe releases a previously registered subscriber.
+func (e *Engine) Unsubscribe(id int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if ch, ok := e.subs[id]; ok {
+		delete(e.subs, id)
+		close(ch)
+	}
+}
+
+// broadcast pushes the current state to all subscribers without blocking.
+func (e *Engine) broadcast() {
+	e.mu.RLock()
+	st := e.cloneState()
+	subs := make([]chan protocol.VaultState, 0, len(e.subs))
+	for _, ch := range e.subs {
+		subs = append(subs, ch)
+	}
+	e.mu.RUnlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- st:
+		default:
+			// Slow consumer: drop this frame rather than stall the engine.
+		}
+	}
+}
+
+// cloneState returns a deep-enough copy of the state for safe external reads.
+// Callers must hold at least a read lock.
+func (e *Engine) cloneState() protocol.VaultState {
+	st := e.state
+	st.Resources = append([]protocol.ResourceStatus(nil), e.state.Resources...)
+	st.SystemList = append([]protocol.SystemStatus(nil), e.state.SystemList...)
+	st.Alerts = append([]protocol.Alert(nil), e.alerts...)
+	// newest-first, capped for transport
+	limit := 25
+	if limit > len(e.events) {
+		limit = len(e.events)
+	}
+	recent := make([]protocol.EventRecord, 0, limit)
+	for i := len(e.events) - 1; i >= 0 && len(recent) < limit; i-- {
+		recent = append(recent, e.events[i])
+	}
+	st.RecentEvents = recent
+	return st
+}

--- a/internal/simulation/engine.go
+++ b/internal/simulation/engine.go
@@ -82,6 +82,11 @@ type Engine struct {
 	subs   map[int]chan protocol.VaultState
 	nextID int
 
+	// procMu serializes interval processing so the automatic run loop and an
+	// explicit Step can never process concurrently (protecting the engine's
+	// single RNG and its read-modify-write database access).
+	procMu sync.Mutex
+
 	// lifecycle
 	runMu   sync.Mutex
 	running bool
@@ -108,6 +113,7 @@ func New(db *database.DB, cfg *config.Config, clock *util.VaultClock) *Engine {
 		status:   protocol.SimPaused,
 		dailyUse: make(map[string]float64),
 		subs:     make(map[int]chan protocol.VaultState),
+		events:   make([]protocol.EventRecord, 0, eventBufferSize),
 	}
 	if sd, err := cfg.Simulation.StartDateTime(); err == nil {
 		e.sealDate = sd
@@ -387,16 +393,15 @@ func (e *Engine) Unsubscribe(id int) {
 }
 
 // broadcast pushes the current state to all subscribers without blocking.
+//
+// The non-blocking sends are performed while holding the read lock. Because
+// Unsubscribe (which closes channels) takes the write lock, it cannot run
+// concurrently with broadcast, so a send can never target a closed channel.
 func (e *Engine) broadcast() {
 	e.mu.RLock()
+	defer e.mu.RUnlock()
 	st := e.cloneState()
-	subs := make([]chan protocol.VaultState, 0, len(e.subs))
 	for _, ch := range e.subs {
-		subs = append(subs, ch)
-	}
-	e.mu.RUnlock()
-
-	for _, ch := range subs {
 		select {
 		case ch <- st:
 		default:

--- a/internal/simulation/engine_test.go
+++ b/internal/simulation/engine_test.go
@@ -1,0 +1,248 @@
+package simulation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/config"
+	"github.com/vtuos/vtuos/internal/database"
+	"github.com/vtuos/vtuos/internal/database/seed"
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/util"
+)
+
+// newTestEngine builds an in-memory, migrated, seeded vault and returns a
+// started engine with the vault clock paused (so progression is driven by Step).
+func newTestEngine(t *testing.T) (*Engine, *database.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := database.NewInMemory()
+	if err != nil {
+		t.Fatalf("creating in-memory db: %v", err)
+	}
+
+	migrator, err := database.NewMigrator(db)
+	if err != nil {
+		t.Fatalf("creating migrator: %v", err)
+	}
+	if _, err := migrator.MigrateUp(ctx); err != nil {
+		t.Fatalf("running migrations: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.Vault.Number = 76
+	cfg.Simulation.Enabled = false // hold the run loop; we drive with Step
+
+	sealDate := time.Date(2077, 10, 23, 9, 47, 0, 0, time.UTC)
+	seedCfg := seed.Config{
+		VaultNumber:      cfg.Vault.Number,
+		SealDate:         sealDate,
+		TargetPopulation: 80,
+		FamilyHouseholds: 12,
+		SingleHouseholds: 10,
+		RandomSeed:       2077,
+	}
+	if err := seed.NewGenerator(db.DB, seedCfg).Generate(ctx); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	clock := util.NewVaultClock(sealDate, cfg.Simulation.TimeScale)
+	clock.Pause()
+
+	eng := New(db, cfg, clock)
+	if err := eng.Start(ctx); err != nil {
+		t.Fatalf("starting engine: %v", err)
+	}
+	return eng, db
+}
+
+func tableCount(t *testing.T, db *database.DB, table string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("counting %s: %v", table, err)
+	}
+	return n
+}
+
+func TestEngineStartEnsuresCoreSystems(t *testing.T) {
+	eng, db := newTestEngine(t)
+	defer eng.Stop(context.Background())
+
+	if got := tableCount(t, db, "facility_systems"); got != len(coreSystems) {
+		t.Fatalf("expected %d core systems, got %d", len(coreSystems), got)
+	}
+
+	st := eng.Snapshot()
+	if st.Systems.Total != len(coreSystems) {
+		t.Errorf("snapshot systems total = %d, want %d", st.Systems.Total, len(coreSystems))
+	}
+	if st.Population.Active == 0 {
+		t.Error("expected a non-zero active population in snapshot")
+	}
+	if len(st.Resources) == 0 {
+		t.Error("expected resource categories in snapshot")
+	}
+	if st.Power.GenerationKW <= 0 {
+		t.Errorf("expected positive power generation, got %.1f", st.Power.GenerationKW)
+	}
+}
+
+func TestEngineStepConsumesResources(t *testing.T) {
+	ctx := context.Background()
+	eng, db := newTestEngine(t)
+	defer eng.Stop(ctx)
+
+	consumptionBefore := consumptionTxns(t, db)
+
+	// Advance ten simulated days.
+	if err := eng.Step(ctx, 24*10); err != nil {
+		t.Fatalf("stepping: %v", err)
+	}
+
+	consumptionAfter := consumptionTxns(t, db)
+	if consumptionAfter <= consumptionBefore {
+		t.Errorf("expected consumption transactions to increase (before=%d after=%d)",
+			consumptionBefore, consumptionAfter)
+	}
+
+	st := eng.Snapshot()
+	if st.ElapsedDays < 10 {
+		t.Errorf("expected at least 10 elapsed days, got %d", st.ElapsedDays)
+	}
+	if st.TickCount < 240 {
+		t.Errorf("expected at least 240 ticks, got %d", st.TickCount)
+	}
+	// Daily-use figures should be populated after processing.
+	foundUse := false
+	for _, r := range st.Resources {
+		if r.DailyUse > 0 {
+			foundUse = true
+		}
+	}
+	if !foundUse {
+		t.Error("expected at least one resource with a non-zero daily use")
+	}
+}
+
+func consumptionTxns(t *testing.T, db *database.DB) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM resource_transactions WHERE transaction_type='CONSUMPTION'").Scan(&n); err != nil {
+		t.Fatalf("counting consumption: %v", err)
+	}
+	return n
+}
+
+func TestEngineControls(t *testing.T) {
+	ctx := context.Background()
+	eng, _ := newTestEngine(t)
+	defer eng.Stop(ctx)
+
+	eng.Resume()
+	if eng.Status() != protocol.SimRunning {
+		t.Errorf("after Resume status = %s, want RUNNING", eng.Status())
+	}
+	eng.Pause()
+	if eng.Status() != protocol.SimPaused {
+		t.Errorf("after Pause status = %s, want PAUSED", eng.Status())
+	}
+	if err := eng.SetTimeScale(120); err != nil {
+		t.Fatalf("SetTimeScale: %v", err)
+	}
+	if eng.Clock().TimeScale() != 120 {
+		t.Errorf("time scale = %.0f, want 120", eng.Clock().TimeScale())
+	}
+	if err := eng.SetTimeScale(-1); err == nil {
+		t.Error("expected error for negative time scale")
+	}
+}
+
+func TestEngineDeterministic(t *testing.T) {
+	ctx := context.Background()
+
+	run := func() (uint64, int, int, int) {
+		eng, db := newTestEngine(t)
+		defer eng.Stop(ctx)
+		if err := eng.Step(ctx, 24*30); err != nil {
+			t.Fatalf("stepping: %v", err)
+		}
+		events := tableCount(t, db, "simulation_events")
+		return eng.TickCount(), eng.Births(), eng.Deaths(), events
+	}
+
+	t1, b1, d1, e1 := run()
+	t2, b2, d2, e2 := run()
+
+	if t1 != t2 || b1 != b2 || d1 != d2 || e1 != e2 {
+		t.Errorf("non-deterministic run:\n  run1: ticks=%d births=%d deaths=%d events=%d\n  run2: ticks=%d births=%d deaths=%d events=%d",
+			t1, b1, d1, e1, t2, b2, d2, e2)
+	}
+}
+
+func TestEnginePersistenceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	eng, db := newTestEngine(t)
+
+	if err := eng.Step(ctx, 24*5); err != nil {
+		t.Fatalf("stepping: %v", err)
+	}
+	births, deaths, tick := eng.Births(), eng.Deaths(), eng.TickCount()
+	if err := eng.saveState(ctx); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+	eng.Stop(ctx)
+
+	// A fresh engine over the same database should restore continuity.
+	cfg := config.Default()
+	cfg.Vault.Number = 76
+	cfg.Simulation.Enabled = false
+	clock := util.NewVaultClock(time.Date(2077, 10, 23, 9, 47, 0, 0, time.UTC), 60)
+	clock.Pause()
+	eng2 := New(db, cfg, clock)
+	if err := eng2.Start(ctx); err != nil {
+		t.Fatalf("starting second engine: %v", err)
+	}
+	defer eng2.Stop(ctx)
+
+	if eng2.Births() != births || eng2.Deaths() != deaths || eng2.TickCount() != tick {
+		t.Errorf("continuity not restored: got births=%d deaths=%d tick=%d, want births=%d deaths=%d tick=%d",
+			eng2.Births(), eng2.Deaths(), eng2.TickCount(), births, deaths, tick)
+	}
+	// The restored clock should be at or after the persisted vault time.
+	if eng2.Clock().Now().Before(clock.Now().Add(-time.Hour)) {
+		t.Error("restored clock did not advance to persisted vault time")
+	}
+}
+
+func TestEngineSubscribe(t *testing.T) {
+	ctx := context.Background()
+	eng, _ := newTestEngine(t)
+	defer eng.Stop(ctx)
+
+	id, ch := eng.Subscribe()
+	defer eng.Unsubscribe(id)
+
+	// The subscription is primed with the current state immediately.
+	select {
+	case st := <-ch:
+		if st.SchemaVersion != protocol.Version {
+			t.Errorf("primed state schema = %q, want %q", st.SchemaVersion, protocol.Version)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive primed state")
+	}
+
+	// A step should push a fresh frame.
+	if err := eng.Step(ctx, 24); err != nil {
+		t.Fatalf("stepping: %v", err)
+	}
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive state after step")
+	}
+}

--- a/internal/simulation/engine_test.go
+++ b/internal/simulation/engine_test.go
@@ -2,6 +2,7 @@ package simulation
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -216,6 +217,49 @@ func TestEnginePersistenceRoundTrip(t *testing.T) {
 	if eng2.Clock().Now().Before(clock.Now().Add(-time.Hour)) {
 		t.Error("restored clock did not advance to persisted vault time")
 	}
+}
+
+func TestEngineConcurrentSubscribeBroadcast(t *testing.T) {
+	ctx := context.Background()
+	eng, _ := newTestEngine(t)
+	defer eng.Stop(ctx)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Continuously subscribe/unsubscribe while broadcasts occur — this is the
+	// interleaving that previously sent on a closed channel.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				id, ch := eng.Subscribe()
+				// Drain a little so the buffer can fill, then release.
+				select {
+				case <-ch:
+				default:
+				}
+				eng.Unsubscribe(id)
+			}
+		}()
+	}
+
+	// Drive broadcasts via stepping and direct control changes.
+	for i := 0; i < 30; i++ {
+		eng.Pause()
+		eng.Resume()
+		if err := eng.Step(ctx, 6); err != nil {
+			t.Fatalf("step: %v", err)
+		}
+	}
+	close(stop)
+	wg.Wait()
 }
 
 func TestEngineSubscribe(t *testing.T) {

--- a/internal/simulation/events.go
+++ b/internal/simulation/events.go
@@ -1,0 +1,90 @@
+package simulation
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+	"github.com/vtuos/vtuos/internal/util"
+)
+
+// Event categories used in the operational log.
+const (
+	catResource   = "RESOURCE"
+	catFacility   = "FACILITY"
+	catPopulation = "POPULATION"
+	catSecurity   = "SECURITY"
+	catMedical    = "MEDICAL"
+	catDiscovery  = "DISCOVERY"
+	catSystem     = "SYSTEM"
+)
+
+// emitEvent records an operational occurrence to the in-memory feed, the
+// persistent simulation_events table, and the immutable audit log. It is
+// best-effort with respect to persistence: a database error is logged but does
+// not abort the operational cycle.
+func (e *Engine) emitEvent(ctx context.Context, asOf time.Time, category, evType string, severity protocol.AlertLevel, summary, detail string) {
+	rec := protocol.EventRecord{
+		ID:        e.idGen.NewID(),
+		VaultTime: asOf,
+		Category:  category,
+		Type:      evType,
+		Severity:  severity,
+		Summary:   summary,
+		Detail:    detail,
+	}
+
+	e.mu.Lock()
+	e.events = append(e.events, rec)
+	if len(e.events) > eventBufferSize {
+		e.events = e.events[len(e.events)-eventBufferSize:]
+	}
+	e.mu.Unlock()
+
+	e.persistEvent(ctx, rec)
+	e.log.Info("operational event",
+		"category", category, "type", evType, "severity", string(severity), "summary", summary)
+}
+
+// persistEvent writes the event to simulation_events and the audit log.
+func (e *Engine) persistEvent(ctx context.Context, rec protocol.EventRecord) {
+	payload, _ := json.Marshal(map[string]string{
+		"category": rec.Category,
+		"severity": string(rec.Severity),
+		"summary":  rec.Summary,
+		"detail":   rec.Detail,
+	})
+
+	const evInsert = `INSERT INTO simulation_events
+		(id, event_type, scheduled_time, processed_at, status, priority, payload, result, created_at)
+		VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?, ?, ?)`
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := e.db.ExecContext(ctx, evInsert,
+		rec.ID, rec.Type, rec.VaultTime.UTC().Format(time.RFC3339), now,
+		severityPriority(rec.Severity), string(payload), rec.Summary, now,
+	); err != nil {
+		e.log.Debug("persisting simulation event failed", "error", err)
+	}
+
+	const auditInsert = `INSERT INTO audit_log
+		(id, timestamp, actor_type, actor_id, action, entity_type, entity_id, new_values, terminal_id)
+		VALUES (?, ?, 'SIMULATION', 'control-core', ?, ?, ?, ?, 'SIM')`
+	if _, err := e.db.ExecContext(ctx, auditInsert,
+		e.idGen.NewID(), rec.VaultTime.UTC().Format(util.DateTimeFormat),
+		rec.Type, rec.Category, rec.ID, rec.Summary,
+	); err != nil {
+		e.log.Debug("persisting audit entry failed", "error", err)
+	}
+}
+
+func severityPriority(level protocol.AlertLevel) int {
+	switch level {
+	case protocol.AlertCritical:
+		return 100
+	case protocol.AlertWarning:
+		return 50
+	default:
+		return 10
+	}
+}

--- a/internal/simulation/events.go
+++ b/internal/simulation/events.go
@@ -38,7 +38,10 @@ func (e *Engine) emitEvent(ctx context.Context, asOf time.Time, category, evType
 	e.mu.Lock()
 	e.events = append(e.events, rec)
 	if len(e.events) > eventBufferSize {
-		e.events = e.events[len(e.events)-eventBufferSize:]
+		// Drop the oldest entry in place, retaining the backing array's
+		// capacity to avoid a reallocation on every append past the cap.
+		copy(e.events, e.events[len(e.events)-eventBufferSize:])
+		e.events = e.events[:eventBufferSize]
 	}
 	e.mu.Unlock()
 

--- a/internal/simulation/incidents.go
+++ b/internal/simulation/incidents.go
@@ -264,10 +264,11 @@ func (e *Engine) randomSystem(ctx context.Context, where string) *models.Facilit
 }
 
 // randomOffset returns a deterministic random offset within the row count
-// produced by the given COUNT(*) query, or -1 if there are no rows.
-func (e *Engine) randomOffset(ctx context.Context, countQuery string) int {
+// produced by the given COUNT(*) query, or -1 if there are no rows. Query
+// arguments are passed through as bind parameters.
+func (e *Engine) randomOffset(ctx context.Context, countQuery string, args ...any) int {
 	var n int
-	if err := e.db.QueryRowContext(ctx, countQuery).Scan(&n); err != nil || n <= 0 {
+	if err := e.db.QueryRowContext(ctx, countQuery, args...).Scan(&n); err != nil || n <= 0 {
 		return -1
 	}
 	return e.rng.Intn(n)

--- a/internal/simulation/incidents.go
+++ b/internal/simulation/incidents.go
@@ -58,7 +58,7 @@ func (e *Engine) rollIncidents(ctx context.Context, asOf time.Time) {
 		w  int
 	}
 	table := []weighted{
-		{e.incidentEquipmentFault, 30 + int((100-avgEff))},
+		{e.incidentEquipmentFault, 30 + int((100 - avgEff))},
 		{e.incidentContamination, 15},
 		{e.incidentIllness, 20},
 		{e.incidentDiscovery, 12},

--- a/internal/simulation/incidents.go
+++ b/internal/simulation/incidents.go
@@ -1,0 +1,274 @@
+package simulation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/config"
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// dailyIncidentProbability maps the configured event frequency to the daily
+// probability that an unplanned operational incident occurs.
+func dailyIncidentProbability(freq config.EventFrequency) float64 {
+	switch freq {
+	case config.EventFrequencyMinimal:
+		return 0.05
+	case config.EventFrequencyReduced:
+		return 0.12
+	case config.EventFrequencyIncreased:
+		return 0.45
+	case config.EventFrequencyChaotic:
+		return 0.80
+	default: // normal or unset
+		return 0.25
+	}
+}
+
+// rollIncidents determines whether an unplanned operational incident occurs on
+// the given day and, if so, generates one. Incident weighting is modified by the
+// vault's current condition: failing systems make equipment faults more likely,
+// scarce resources make security incidents more likely, and crowding raises the
+// chance of conflict.
+func (e *Engine) rollIncidents(ctx context.Context, asOf time.Time) {
+	if !e.cfg.Simulation.AutoEvents {
+		return
+	}
+	if e.rng.Float64() >= dailyIncidentProbability(e.cfg.Simulation.EventFrequency) {
+		return
+	}
+
+	e.mu.RLock()
+	avgEff := e.state.Systems.AvgEfficiency
+	loadPct := e.state.Population.LoadPct
+	scarce := false
+	for _, r := range e.state.Resources {
+		if r.Status == "CRITICAL" || r.Status == "WARNING" {
+			scarce = true
+			break
+		}
+	}
+	e.mu.RUnlock()
+
+	// Build a weighted incident table reflecting current conditions.
+	type weighted struct {
+		fn func(context.Context, time.Time)
+		w  int
+	}
+	table := []weighted{
+		{e.incidentEquipmentFault, 30 + int((100-avgEff))},
+		{e.incidentContamination, 15},
+		{e.incidentIllness, 20},
+		{e.incidentDiscovery, 12},
+	}
+	secWeight := 10
+	if scarce {
+		secWeight += 20
+	}
+	if loadPct > 95 {
+		secWeight += 15
+	}
+	table = append(table, weighted{e.incidentSecurity, secWeight})
+
+	total := 0
+	for _, t := range table {
+		total += t.w
+	}
+	if total <= 0 {
+		return
+	}
+	pick := e.rng.Intn(total)
+	for _, t := range table {
+		if pick < t.w {
+			t.fn(ctx, asOf)
+			return
+		}
+		pick -= t.w
+	}
+}
+
+// incidentEquipmentFault applies a sudden efficiency loss to a random
+// operational system, modelling an unplanned fault.
+func (e *Engine) incidentEquipmentFault(ctx context.Context, asOf time.Time) {
+	sys := e.randomSystem(ctx, "WHERE status IN ('OPERATIONAL','DEGRADED')")
+	if sys == nil {
+		return
+	}
+	drop := 15.0 + e.rng.Float64()*35.0
+	newEff := sys.EfficiencyPercent - drop
+	if newEff < 0 {
+		newEff = 0
+	}
+	newStatus := models.SystemStatusDegraded
+	severity := protocol.AlertWarning
+	if newEff < efficiencyFailedBelow {
+		newStatus = models.SystemStatusFailed
+		severity = protocol.AlertCritical
+	}
+	if err := e.updateSystemDaily(ctx, sys.ID, newEff, newStatus, sys.TotalRuntimeHours, outputFor(sys, newEff)); err != nil {
+		return
+	}
+	e.emitEvent(ctx, asOf, catFacility, "EQUIPMENT_FAULT", severity,
+		fmt.Sprintf("Unplanned fault: %s", sys.Name),
+		fmt.Sprintf("%s (%s) lost %.0f points of efficiency to an unplanned fault; now at %.0f%%.",
+			sys.Name, sys.SystemCode, drop, newEff))
+}
+
+// incidentContamination quarantines a random available stock lot.
+func (e *Engine) incidentContamination(ctx context.Context, asOf time.Time) {
+	var stockID, location string
+	var itemName string
+	const q = `SELECT rs.id, rs.storage_location, ri.name
+		FROM resource_stocks rs JOIN resource_items ri ON ri.id = rs.item_id
+		WHERE rs.status = 'AVAILABLE' AND rs.quantity > 0
+		LIMIT 1 OFFSET ?`
+	offset := e.randomOffset(ctx, "SELECT COUNT(*) FROM resource_stocks WHERE status='AVAILABLE' AND quantity > 0")
+	if offset < 0 {
+		return
+	}
+	if err := e.db.QueryRowContext(ctx, q, offset).Scan(&stockID, &location, &itemName); err != nil {
+		return
+	}
+	if _, err := e.db.ExecContext(ctx,
+		`UPDATE resource_stocks SET status = 'QUARANTINE', updated_at = ? WHERE id = ?`,
+		time.Now().UTC().Format(time.RFC3339), stockID); err != nil {
+		return
+	}
+	e.emitEvent(ctx, asOf, catResource, "CONTAMINATION", protocol.AlertWarning,
+		fmt.Sprintf("Contamination: %s", itemName),
+		fmt.Sprintf("A lot of %s in %s was flagged and moved to quarantine pending assay.", itemName, location))
+}
+
+// incidentIllness records a contagious medical condition for a random resident
+// and, for severe cases, moves them to quarantine.
+func (e *Engine) incidentIllness(ctx context.Context, asOf time.Time) {
+	var residentID, name string
+	const q = `SELECT id, surname || ', ' || given_names FROM residents
+		WHERE status = 'ACTIVE' LIMIT 1 OFFSET ?`
+	offset := e.randomOffset(ctx, "SELECT COUNT(*) FROM residents WHERE status='ACTIVE'")
+	if offset < 0 {
+		return
+	}
+	if err := e.db.QueryRowContext(ctx, q, offset).Scan(&residentID, &name); err != nil {
+		return
+	}
+
+	severe := e.rng.Float64() < 0.3
+	severity := "MODERATE"
+	if severe {
+		severity = "SEVERE"
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	const cond = `INSERT INTO medical_conditions
+		(id, resident_id, condition_code, condition_name, onset_date, severity,
+		 is_chronic, is_genetic, is_contagious, created_at, updated_at)
+		VALUES (?, ?, 'INF-001', 'Communicable infection', ?, ?, 0, 0, 1, ?, ?)`
+	if _, err := e.db.ExecContext(ctx, cond,
+		e.idGen.NewID(), residentID, asOf.UTC().Format(time.RFC3339), severity, now, now); err != nil {
+		return
+	}
+
+	level := protocol.AlertWarning
+	detail := fmt.Sprintf("%s presented with a communicable infection (%s). Contact tracing initiated.", name, severity)
+	if severe {
+		level = protocol.AlertCritical
+		if _, err := e.db.ExecContext(ctx,
+			`UPDATE residents SET status = 'QUARANTINE', updated_at = ? WHERE id = ?`,
+			now, residentID); err != nil {
+			e.log.Debug("quarantine update failed", "error", err)
+		}
+		detail = fmt.Sprintf("%s placed in medical quarantine with a severe communicable infection.", name)
+	}
+	e.emitEvent(ctx, asOf, catMedical, "ILLNESS", level, "Communicable infection reported", detail)
+}
+
+// incidentSecurity records a security incident.
+func (e *Engine) incidentSecurity(ctx context.Context, asOf time.Time) {
+	kinds := []struct {
+		typ, sev, desc string
+	}{
+		{"ALTERCATION", "MINOR", "A verbal altercation between residents was reported and de-escalated."},
+		{"THEFT", "MODERATE", "Ration pilferage was reported from a storage area; investigation opened."},
+		{"INSUBORDINATION", "MINOR", "A work-shift refusal was logged and referred to the department head."},
+		{"UNAUTHORIZED_ACCESS", "MAJOR", "An unauthorised access attempt was detected at a restricted door."},
+	}
+	k := kinds[e.rng.Intn(len(kinds))]
+	now := time.Now().UTC().Format(time.RFC3339)
+	incidentNum := fmt.Sprintf("INC-%s-%04d", asOf.Format("20060102"), e.rng.Intn(10000))
+	const ins = `INSERT INTO security_incidents
+		(id, incident_number, incident_type, severity, description, status,
+		 occurred_at, reported_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, 'OPEN', ?, ?, ?, ?)`
+	if _, err := e.db.ExecContext(ctx, ins,
+		e.idGen.NewID(), incidentNum, k.typ, k.sev, k.desc,
+		asOf.UTC().Format(time.RFC3339), asOf.UTC().Format(time.RFC3339), now, now); err != nil {
+		e.log.Debug("inserting security incident failed", "error", err)
+		return
+	}
+	level := protocol.AlertInfo
+	if k.sev == "MAJOR" {
+		level = protocol.AlertWarning
+	}
+	e.emitEvent(ctx, asOf, catSecurity, "SECURITY_INCIDENT", level,
+		fmt.Sprintf("Security: %s (%s)", k.typ, incidentNum), k.desc)
+}
+
+// incidentDiscovery is a positive incident: a recovered cache adds stock to a
+// random producible-or-stored resource.
+func (e *Engine) incidentDiscovery(ctx context.Context, asOf time.Time) {
+	var itemID, itemName, unit string
+	const q = `SELECT id, name, unit_of_measure FROM resource_items LIMIT 1 OFFSET ?`
+	offset := e.randomOffset(ctx, "SELECT COUNT(*) FROM resource_items")
+	if offset < 0 {
+		return
+	}
+	if err := e.db.QueryRowContext(ctx, q, offset).Scan(&itemID, &itemName, &unit); err != nil {
+		return
+	}
+	qty := 20.0 + e.rng.Float64()*180.0
+	const stock = `INSERT INTO resource_stocks
+		(id, item_id, lot_number, quantity, quantity_reserved, storage_location,
+		 received_date, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 0, 'STORAGE-RECOVERED', ?, 'AVAILABLE', ?, ?)`
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := e.db.ExecContext(ctx, stock,
+		e.idGen.NewID(), itemID, fmt.Sprintf("LOT-RCV-%s", asOf.Format("20060102")),
+		qty, asOf.UTC().Format(time.RFC3339), now, now); err != nil {
+		return
+	}
+	e.emitEvent(ctx, asOf, catDiscovery, "CACHE_RECOVERED", protocol.AlertInfo,
+		fmt.Sprintf("Cache recovered: %s", itemName),
+		fmt.Sprintf("A sealed storage cache was located and inventoried: %.0f %s of %s added to stock.",
+			qty, unit, itemName))
+}
+
+// randomSystem returns a random facility system matching the given WHERE clause,
+// or nil if none match.
+func (e *Engine) randomSystem(ctx context.Context, where string) *models.FacilitySystem {
+	offset := e.randomOffset(ctx, "SELECT COUNT(*) FROM facility_systems "+where)
+	if offset < 0 {
+		return nil
+	}
+	var id string
+	q := "SELECT id FROM facility_systems " + where + " LIMIT 1 OFFSET ?"
+	if err := e.db.QueryRowContext(ctx, q, offset).Scan(&id); err != nil {
+		return nil
+	}
+	sys, err := e.fac.GetSystem(ctx, id)
+	if err != nil {
+		return nil
+	}
+	return sys
+}
+
+// randomOffset returns a deterministic random offset within the row count
+// produced by the given COUNT(*) query, or -1 if there are no rows.
+func (e *Engine) randomOffset(ctx context.Context, countQuery string) int {
+	var n int
+	if err := e.db.QueryRowContext(ctx, countQuery).Scan(&n); err != nil || n <= 0 {
+		return -1
+	}
+	return e.rng.Intn(n)
+}

--- a/internal/simulation/metrics.go
+++ b/internal/simulation/metrics.go
@@ -1,0 +1,228 @@
+package simulation
+
+import (
+	"context"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// nominalDrawKW is the approximate electrical draw of a running system by
+// category, used to estimate the vault's power balance for the operations board.
+var nominalDrawKW = map[string]float64{
+	"POWER":           0,
+	"WATER":           40,
+	"HVAC":            60,
+	"WASTE":           25,
+	"SECURITY":        15,
+	"MEDICAL":         20,
+	"FOOD_PRODUCTION": 35,
+	"COMMUNICATIONS":  5,
+	"STRUCTURAL":      5,
+}
+
+// recomputeState rebuilds the operational snapshot from current database state,
+// re-evaluates alerts, stores the result, and notifies subscribers indirectly
+// via the caller's broadcast.
+func (e *Engine) recomputeState(ctx context.Context) error {
+	now := e.clock.Now()
+
+	pop := e.buildPopulation(ctx, now)
+	res := e.buildResources(ctx)
+	sysSummary, sysList := e.buildSystems(ctx, now)
+	power := e.buildPower(sysList)
+
+	e.mu.Lock()
+	e.state.SchemaVersion = protocol.Version
+	e.state.Generated = time.Now().UTC()
+	e.state.VaultDesignation = e.cfg.Vault.Designation
+	e.state.VaultNumber = e.cfg.Vault.Number
+	e.state.Status = e.status
+	e.state.TimeScale = e.clock.TimeScale()
+	e.state.VaultTime = now
+	e.state.SealDate = e.sealDate
+	e.state.TickCount = e.tickN
+	if !e.sealDate.IsZero() {
+		elapsed := now.Sub(e.sealDate)
+		e.state.ElapsedDays = int(elapsed.Hours() / 24)
+		e.state.ElapsedYears = int(elapsed.Hours() / 8760)
+	}
+	pop.Births = e.births
+	pop.Deaths = e.deaths
+	e.state.Population = pop
+	e.state.Resources = res
+	e.state.Systems = sysSummary
+	e.state.SystemList = sysList
+	e.state.Power = power
+	e.alerts = e.evaluateAlerts(e.state, e.alerts)
+	e.state.Alerts = append([]protocol.Alert(nil), e.alerts...)
+	e.mu.Unlock()
+	return nil
+}
+
+// buildPopulation queries the census for the operations board.
+func (e *Engine) buildPopulation(ctx context.Context, asOf time.Time) protocol.PopulationStatus {
+	var p protocol.PopulationStatus
+	p.Capacity = e.cfg.Vault.DesignedCapacity
+
+	rows := e.db.QueryRowContext(ctx, `SELECT
+		COALESCE(SUM(CASE WHEN status='ACTIVE' THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN status='DECEASED' THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN status='QUARANTINE' THEN 1 ELSE 0 END),0)
+		FROM residents`)
+	_ = rows.Scan(&p.Active, &p.Deceased, &p.Quarantined)
+
+	_ = e.db.QueryRowContext(ctx,
+		`SELECT COALESCE(AVG((julianday(?) - julianday(date_of_birth))/365.25),0)
+		 FROM residents WHERE status='ACTIVE'`,
+		asOf.UTC().Format(time.RFC3339)).Scan(&p.AverageAge)
+
+	if p.Capacity > 0 {
+		p.LoadPct = float64(p.Active) / float64(p.Capacity) * 100
+	}
+	return p
+}
+
+// buildResources summarises on-hand inventory by category with runway forecasts.
+func (e *Engine) buildResources(ctx context.Context) []protocol.ResourceStatus {
+	const q = `SELECT rc.code, rc.name, rc.unit_of_measure,
+		COALESCE(SUM(CASE WHEN rs.status='AVAILABLE' THEN rs.quantity ELSE 0 END),0)
+		FROM resource_categories rc
+		LEFT JOIN resource_items ri ON ri.category_id = rc.id
+		LEFT JOIN resource_stocks rs ON rs.item_id = ri.id
+		GROUP BY rc.id ORDER BY rc.code`
+	rows, err := e.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	e.mu.RLock()
+	use := make(map[string]float64, len(e.dailyUse))
+	for k, v := range e.dailyUse {
+		use[k] = v
+	}
+	e.mu.RUnlock()
+
+	var out []protocol.ResourceStatus
+	for rows.Next() {
+		var code, name, unit string
+		var onHand float64
+		if err := rows.Scan(&code, &name, &unit, &onHand); err != nil {
+			continue
+		}
+		rs := protocol.ResourceStatus{
+			Category: code, Label: name, Unit: unit, OnHand: onHand,
+			DailyUse: use[code], RunwayDays: -1, Status: "OK",
+		}
+		if rs.DailyUse > 0 {
+			rs.RunwayDays = int(onHand / rs.DailyUse)
+			switch {
+			case rs.RunwayDays < 7:
+				rs.Status = "CRITICAL"
+			case rs.RunwayDays < 30:
+				rs.Status = "WARNING"
+			case rs.RunwayDays < 90:
+				rs.Status = "WATCH"
+			}
+			rs.FillFraction = clamp(float64(rs.RunwayDays)/365.0, 0, 1)
+		} else {
+			rs.FillFraction = 1
+		}
+		out = append(out, rs)
+	}
+	return out
+}
+
+// buildSystems returns the facility health summary and a per-system list.
+func (e *Engine) buildSystems(ctx context.Context, asOf time.Time) (protocol.SystemsSummary, []protocol.SystemStatus) {
+	var summary protocol.SystemsSummary
+	if stats, err := e.fac.GetFacilityStats(ctx, asOf); err == nil {
+		summary = protocol.SystemsSummary{
+			Total:         stats.TotalSystems,
+			Operational:   stats.Operational,
+			Degraded:      stats.Degraded,
+			Offline:       stats.Offline,
+			Failed:        stats.Failed,
+			AvgEfficiency: stats.AvgEfficiency,
+			OverdueMaint:  stats.OverdueMaintenance,
+		}
+	}
+
+	list, err := e.fac.ListSystems(ctx, models.FacilitySystemFilter{}, models.Pagination{Page: 1, PageSize: 500})
+	if err != nil {
+		return summary, nil
+	}
+	out := make([]protocol.SystemStatus, 0, len(list.Systems))
+	for _, s := range list.Systems {
+		out = append(out, protocol.SystemStatus{
+			Code:       s.SystemCode,
+			Name:       s.Name,
+			Category:   string(s.Category),
+			Status:     string(s.Status),
+			Efficiency: s.EfficiencyPercent,
+			Critical:   isCriticalCategory(s.Category),
+		})
+	}
+	return summary, out
+}
+
+// buildPower estimates the vault's electrical balance from current systems.
+func (e *Engine) buildPower(systems []protocol.SystemStatus) protocol.PowerStatus {
+	var gen, cons float64
+	for _, s := range systems {
+		operational := s.Status == string(models.SystemStatusOperational) ||
+			s.Status == string(models.SystemStatusDegraded)
+		if !operational {
+			continue
+		}
+		if s.Category == string(models.SystemCategoryPower) {
+			// Generation handled below via DB for capacity accuracy.
+			continue
+		}
+		cons += nominalDrawKW[s.Category]
+	}
+	// Generation from rated capacity scaled by efficiency.
+	_ = e.db.QueryRowContext(context.Background(),
+		`SELECT COALESCE(SUM(COALESCE(capacity_rating,0)*efficiency_percent/100.0),0)
+		 FROM facility_systems
+		 WHERE category='POWER' AND status IN ('OPERATIONAL','DEGRADED')`).Scan(&gen)
+
+	bal := gen - cons
+	reserve := 0.0
+	if gen > 0 {
+		reserve = bal / gen * 100
+	}
+	return protocol.PowerStatus{
+		GenerationKW:  round1(gen),
+		ConsumptionKW: round1(cons),
+		BalanceKW:     round1(bal),
+		ReservePct:    round1(reserve),
+	}
+}
+
+func isCriticalCategory(c models.SystemCategory) bool {
+	switch c {
+	case models.SystemCategoryPower, models.SystemCategoryWater,
+		models.SystemCategoryHVAC, models.SystemCategoryWaste,
+		models.SystemCategorySecurity:
+		return true
+	default:
+		return false
+	}
+}
+
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func round1(v float64) float64 {
+	return float64(int(v*10+0.5)) / 10
+}

--- a/internal/simulation/metrics.go
+++ b/internal/simulation/metrics.go
@@ -31,7 +31,7 @@ func (e *Engine) recomputeState(ctx context.Context) error {
 	pop := e.buildPopulation(ctx, now)
 	res := e.buildResources(ctx)
 	sysSummary, sysList := e.buildSystems(ctx, now)
-	power := e.buildPower(sysList)
+	power := e.buildPower(ctx, sysList)
 
 	e.mu.Lock()
 	e.state.SchemaVersion = protocol.Version
@@ -73,10 +73,11 @@ func (e *Engine) buildPopulation(ctx context.Context, asOf time.Time) protocol.P
 		FROM residents`)
 	_ = rows.Scan(&p.Active, &p.Deceased, &p.Quarantined)
 
+	// date_of_birth is stored as 'YYYY-MM-DD'; pass the same format to julianday.
 	_ = e.db.QueryRowContext(ctx,
 		`SELECT COALESCE(AVG((julianday(?) - julianday(date_of_birth))/365.25),0)
 		 FROM residents WHERE status='ACTIVE'`,
-		asOf.UTC().Format(time.RFC3339)).Scan(&p.AverageAge)
+		asOf.UTC().Format(time.DateOnly)).Scan(&p.AverageAge)
 
 	if p.Capacity > 0 {
 		p.LoadPct = float64(p.Active) / float64(p.Capacity) * 100
@@ -169,7 +170,7 @@ func (e *Engine) buildSystems(ctx context.Context, asOf time.Time) (protocol.Sys
 }
 
 // buildPower estimates the vault's electrical balance from current systems.
-func (e *Engine) buildPower(systems []protocol.SystemStatus) protocol.PowerStatus {
+func (e *Engine) buildPower(ctx context.Context, systems []protocol.SystemStatus) protocol.PowerStatus {
 	var gen, cons float64
 	for _, s := range systems {
 		operational := s.Status == string(models.SystemStatusOperational) ||
@@ -184,7 +185,7 @@ func (e *Engine) buildPower(systems []protocol.SystemStatus) protocol.PowerStatu
 		cons += nominalDrawKW[s.Category]
 	}
 	// Generation from rated capacity scaled by efficiency.
-	_ = e.db.QueryRowContext(context.Background(),
+	_ = e.db.QueryRowContext(ctx,
 		`SELECT COALESCE(SUM(COALESCE(capacity_rating,0)*efficiency_percent/100.0),0)
 		 FROM facility_systems
 		 WHERE category='POWER' AND status IN ('OPERATIONAL','DEGRADED')`).Scan(&gen)

--- a/internal/simulation/persistence.go
+++ b/internal/simulation/persistence.go
@@ -1,0 +1,94 @@
+package simulation
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// metadata keys used to persist operational continuity across restarts.
+const (
+	mdVaultTime = "vault_time"
+	mdBirths    = "sim_births"
+	mdDeaths    = "sim_deaths"
+	mdTickCount = "sim_tick_count"
+)
+
+// saveState persists the simulation's operational position so the vault resumes
+// where it left off after a restart or power loss.
+func (e *Engine) saveState(ctx context.Context) error {
+	e.mu.RLock()
+	vaultTime := e.clock.Now().UTC().Format(time.RFC3339)
+	births := e.births
+	deaths := e.deaths
+	tick := e.tickN
+	e.mu.RUnlock()
+
+	pairs := map[string]string{
+		mdVaultTime: vaultTime,
+		mdBirths:    strconv.Itoa(births),
+		mdDeaths:    strconv.Itoa(deaths),
+		mdTickCount: strconv.FormatUint(tick, 10),
+	}
+	for k, v := range pairs {
+		if err := e.putMetadata(ctx, k, v); err != nil {
+			return fmt.Errorf("persisting %s: %w", k, err)
+		}
+	}
+	return nil
+}
+
+// loadState restores operational continuity from the metadata table. The vault
+// clock is advanced to the persisted time so progression continues seamlessly.
+func (e *Engine) loadState(ctx context.Context) error {
+	vt, err := e.getMetadata(ctx, mdVaultTime)
+	if err != nil {
+		return err
+	}
+	if vt != "" {
+		if t, perr := time.Parse(time.RFC3339, vt); perr == nil && !t.Before(e.sealDate) {
+			wasPaused := e.clock.IsPaused()
+			e.clock.Pause()
+			if serr := e.clock.SetTime(t); serr == nil {
+				e.lastProc = t
+			}
+			if !wasPaused {
+				e.clock.Resume()
+			}
+		}
+	}
+	if b, err := e.getMetadata(ctx, mdBirths); err == nil && b != "" {
+		e.births, _ = strconv.Atoi(b)
+	}
+	if d, err := e.getMetadata(ctx, mdDeaths); err == nil && d != "" {
+		e.deaths, _ = strconv.Atoi(d)
+	}
+	if t, err := e.getMetadata(ctx, mdTickCount); err == nil && t != "" {
+		if n, perr := strconv.ParseUint(t, 10, 64); perr == nil {
+			e.tickN = n
+		}
+	}
+	return nil
+}
+
+func (e *Engine) putMetadata(ctx context.Context, key, value string) error {
+	const q = `INSERT INTO vault_metadata (key, value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+	_, err := e.db.ExecContext(ctx, q, key, value, time.Now().UTC().Format(time.RFC3339))
+	return err
+}
+
+func (e *Engine) getMetadata(ctx context.Context, key string) (string, error) {
+	var v string
+	err := e.db.QueryRowContext(ctx, `SELECT value FROM vault_metadata WHERE key = ?`, key).Scan(&v)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return v, nil
+}

--- a/internal/simulation/snapshot.go
+++ b/internal/simulation/snapshot.go
@@ -1,0 +1,44 @@
+package simulation
+
+import (
+	"context"
+	"fmt"
+)
+
+// Snapshot captures a consistent copy of the entire vault database to the
+// configured backup directory and returns its path. Operators use snapshots to
+// checkpoint an exhibit before a demonstration and to restore a clean baseline
+// afterward (via `vtuos --restore <path>`), which is the safe way to reset a
+// running vault.
+func (e *Engine) CreateSnapshot(ctx context.Context) (string, error) {
+	if err := e.saveState(ctx); err != nil {
+		e.log.Warn("persisting state before snapshot failed", "error", err)
+	}
+	path, err := e.db.Backup(ctx)
+	if err != nil {
+		return "", fmt.Errorf("creating snapshot: %w", err)
+	}
+	e.log.Info("vault snapshot created", "path", path)
+	return path, nil
+}
+
+// Births returns the cumulative number of births recorded by the engine.
+func (e *Engine) Births() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.births
+}
+
+// Deaths returns the cumulative number of deaths recorded by the engine.
+func (e *Engine) Deaths() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.deaths
+}
+
+// TickCount returns the number of simulated hours processed.
+func (e *Engine) TickCount() uint64 {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.tickN
+}

--- a/internal/simulation/systems_seed.go
+++ b/internal/simulation/systems_seed.go
@@ -1,0 +1,84 @@
+package simulation
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/database"
+	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/services/facilities"
+)
+
+// coreSystem describes a piece of vault infrastructure that any commissioned
+// vault possesses. These are reference data, not random content.
+type coreSystem struct {
+	code     string
+	name     string
+	category models.SystemCategory
+	sector   string
+	level    int
+	capacity float64
+	unit     string
+	interval int
+	mtbf     int
+}
+
+var coreSystems = []coreSystem{
+	{"PWR-RX-01", "Fusion Reactor Core", models.SystemCategoryPower, "CORE", 5, 480, "kW", 180, 87600},
+	{"PWR-GEN-01", "Backup Generator Bank", models.SystemCategoryPower, "CORE", 5, 160, "kW", 120, 43800},
+	{"PWR-DIST-01", "Power Distribution Grid", models.SystemCategoryPower, "CORE", 4, 600, "kW", 90, 26280},
+	{"WTR-PUR-01", "Water Purification Plant", models.SystemCategoryWater, "UTILITY", 3, 12000, "L/day", 60, 17520},
+	{"WTR-REC-01", "Greywater Recycling Unit", models.SystemCategoryWater, "UTILITY", 3, 8000, "L/day", 60, 13140},
+	{"HVAC-FILT-01", "Primary Air Filtration", models.SystemCategoryHVAC, "UTILITY", 2, 100, "%", 45, 21900},
+	{"HVAC-CLIM-01", "Climate Control System", models.SystemCategoryHVAC, "UTILITY", 2, 100, "%", 90, 26280},
+	{"WST-PROC-01", "Sewage Processing Plant", models.SystemCategoryWaste, "UTILITY", 1, 100, "%", 60, 17520},
+	{"SEC-DOOR-01", "Vault Door Control", models.SystemCategorySecurity, "ENTRANCE", 1, 100, "%", 30, 35040},
+	{"SEC-SURV-01", "Surveillance Network", models.SystemCategorySecurity, "CORE", 4, 100, "%", 90, 26280},
+	{"MED-CLIN-01", "Medical Bay Equipment", models.SystemCategoryMedical, "MEDICAL", 2, 100, "%", 90, 21900},
+	{"FOOD-HYDRO-01", "Hydroponics Bay A", models.SystemCategoryFoodProduction, "AGRI", 3, 600, "kg/day", 75, 13140},
+	{"FOOD-HYDRO-02", "Hydroponics Bay B", models.SystemCategoryFoodProduction, "AGRI", 3, 600, "kg/day", 75, 13140},
+	{"COM-INT-01", "Internal Communications", models.SystemCategoryCommunications, "CORE", 4, 100, "%", 180, 43800},
+	{"STR-INT-01", "Structural Integrity Monitor", models.SystemCategoryStructural, "CORE", 6, 100, "%", 365, 87600},
+}
+
+// EnsureCoreSystems creates the vault's core facility systems if none exist.
+// It is idempotent and self-healing: an operational vault always has
+// infrastructure to manage.
+func EnsureCoreSystems(ctx context.Context, db *database.DB, fac *facilities.Service, installDate time.Time) error {
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM facility_systems`).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	if installDate.IsZero() {
+		installDate = time.Now().UTC()
+	}
+	created := 0
+	for _, cs := range coreSystems {
+		cap := cs.capacity
+		mtbf := cs.mtbf
+		_, err := fac.CreateSystem(ctx, facilities.CreateSystemInput{
+			SystemCode:              cs.code,
+			Name:                    cs.name,
+			Category:                cs.category,
+			LocationSector:          cs.sector,
+			LocationLevel:           cs.level,
+			CapacityRating:          &cap,
+			CapacityUnit:            cs.unit,
+			InstallDate:             installDate,
+			MaintenanceIntervalDays: cs.interval,
+			MTBFHours:               &mtbf,
+			Notes:                   "Commissioned core system",
+		})
+		if err != nil {
+			slog.Warn("creating core system failed", "code", cs.code, "error", err)
+			continue
+		}
+		created++
+	}
+	slog.Info("core facility systems ensured", "created", created)
+	return nil
+}

--- a/internal/simulation/tick.go
+++ b/internal/simulation/tick.go
@@ -12,6 +12,11 @@ import (
 // consumption, degradation, maintenance, incidents, demographics) is performed
 // once per simulated day, which bounds database writes regardless of time scale.
 func (e *Engine) advanceTo(ctx context.Context, now time.Time) error {
+	// Serialize processing: the automatic run loop and an explicit Step must
+	// never run a day cycle (or touch the RNG) concurrently.
+	e.procMu.Lock()
+	defer e.procMu.Unlock()
+
 	e.mu.Lock()
 	last := e.lastProc
 	e.mu.Unlock()

--- a/internal/simulation/tick.go
+++ b/internal/simulation/tick.go
@@ -1,0 +1,99 @@
+package simulation
+
+import (
+	"context"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/util"
+)
+
+// advanceTo brings the simulation up to the given vault time. Whole simulated
+// hours are advanced one at a time; the heavy operational accounting (resource
+// consumption, degradation, maintenance, incidents, demographics) is performed
+// once per simulated day, which bounds database writes regardless of time scale.
+func (e *Engine) advanceTo(ctx context.Context, now time.Time) error {
+	e.mu.Lock()
+	last := e.lastProc
+	e.mu.Unlock()
+
+	hours := int(now.Sub(last).Hours())
+	if hours <= 0 {
+		// No whole simulated hour elapsed; refresh the clock-derived fields so
+		// displays keep ticking without touching the database.
+		e.lightweightRefresh()
+		return nil
+	}
+	if hours > maxHoursPerWake {
+		hours = maxHoursPerWake // catch up over subsequent wakes
+	}
+
+	cursor := last
+	daysProcessed := 0
+	for i := 0; i < hours; i++ {
+		prev := cursor
+		cursor = cursor.Add(time.Hour)
+
+		e.mu.Lock()
+		e.tickN++
+		e.mu.Unlock()
+
+		// Cross a calendar day boundary: run the daily operational cycle for
+		// the day that just completed.
+		if !util.IsSameDay(prev, cursor) {
+			if err := e.processDay(ctx, util.StartOfDay(cursor)); err != nil {
+				e.log.Error("daily operational cycle failed",
+					"day", cursor.Format(util.DateFormat), "error", err)
+			}
+			daysProcessed++
+		}
+	}
+
+	e.mu.Lock()
+	e.lastProc = cursor
+	e.mu.Unlock()
+
+	if daysProcessed > 0 {
+		if err := e.saveState(ctx); err != nil {
+			e.log.Warn("could not persist simulation state", "error", err)
+		}
+	}
+
+	if err := e.recomputeState(ctx); err != nil {
+		return err
+	}
+	e.broadcast()
+	return nil
+}
+
+// processDay runs one simulated day of vault operations. Each stage is isolated:
+// a failure in one is logged and the cycle continues, mirroring how an
+// operational system degrades gracefully rather than halting.
+func (e *Engine) processDay(ctx context.Context, asOf time.Time) error {
+	e.consumeDailyResources(ctx, asOf)
+	e.produceDailyResources(ctx, asOf)
+	e.processExpirations(ctx, asOf)
+	e.degradeSystems(ctx, asOf)
+	e.maintenanceSweep(ctx, asOf)
+	e.rollIncidents(ctx, asOf)
+	e.processDemographics(ctx, asOf)
+	return nil
+}
+
+// lightweightRefresh updates only the clock-derived fields of the operational
+// snapshot and notifies subscribers. It performs no database access.
+func (e *Engine) lightweightRefresh() {
+	now := e.clock.Now()
+	e.mu.Lock()
+	e.state.VaultTime = now
+	e.state.Generated = time.Now().UTC()
+	e.state.Status = e.status
+	e.state.TimeScale = e.clock.TimeScale()
+	e.state.TickCount = e.tickN
+	if !e.sealDate.IsZero() {
+		elapsed := now.Sub(e.sealDate)
+		e.state.ElapsedDays = int(elapsed.Hours() / 24)
+		e.state.ElapsedYears = int(elapsed.Hours() / 8760)
+	}
+	e.mu.Unlock()
+	e.broadcast()
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -253,15 +253,19 @@ type populationMsg struct {
 }
 
 type censusLoadedMsg struct {
-	err error
+	result *models.ResidentList
+	err    error
 }
 
 type inventoryLoadedMsg struct {
-	err error
+	categories []*models.ResourceCategory
+	result     *models.StockList
+	err        error
 }
 
 type systemsLoadedMsg struct {
-	err error
+	result *models.FacilitySystemList
+	err    error
 }
 
 // Update implements tea.Model.
@@ -330,20 +334,31 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case censusLoadedMsg:
+		// Mutating the view here, on the UI goroutine, keeps it free of the
+		// data race that arose when the load command mutated it directly.
 		if msg.err != nil {
+			a.censusView.SetLoadError(msg.err)
 			a.AddAlert(AlertWarning, "Failed to load census: "+msg.err.Error())
+		} else {
+			a.censusView.ApplyResidents(msg.result)
 		}
 		return a, nil
 
 	case inventoryLoadedMsg:
 		if msg.err != nil {
+			a.inventoryView.SetLoadError(msg.err)
 			a.AddAlert(AlertWarning, "Failed to load inventory: "+msg.err.Error())
+		} else {
+			a.inventoryView.ApplyStocks(msg.categories, msg.result)
 		}
 		return a, nil
 
 	case systemsLoadedMsg:
 		if msg.err != nil {
+			a.systemsView.SetLoadError(msg.err)
 			a.AddAlert(AlertWarning, "Failed to load systems: "+msg.err.Error())
+		} else {
+			a.systemsView.ApplySystems(msg.result)
 		}
 		return a, nil
 
@@ -761,11 +776,15 @@ func (a *App) registerDeath(resident *models.Resident) tea.Cmd {
 	}
 }
 
-// loadCensus loads the census data.
+// loadCensus loads the census data. Query parameters are snapshotted on the UI
+// goroutine; the command performs only a read-only fetch and returns the result
+// for the Update handler to apply to the view.
 func (a *App) loadCensus() tea.Cmd {
+	filter, page := a.censusView.QueryParams()
+	svc := a.populationSvc
 	return func() tea.Msg {
-		err := a.censusView.Load(context.Background())
-		return censusLoadedMsg{err: err}
+		result, err := svc.ListResidents(context.Background(), filter, page)
+		return censusLoadedMsg{result: result, err: err}
 	}
 }
 
@@ -890,19 +909,27 @@ func (a *App) handleFacilityKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
-// loadSystems loads the facility systems data.
+// loadSystems loads the facility systems data (read-only fetch; applied in Update).
 func (a *App) loadSystems() tea.Cmd {
+	filter, page := a.systemsView.QueryParams()
+	svc := a.facilitySvc
 	return func() tea.Msg {
-		err := a.systemsView.Load(context.Background())
-		return systemsLoadedMsg{err: err}
+		result, err := svc.ListSystems(context.Background(), filter, page)
+		return systemsLoadedMsg{result: result, err: err}
 	}
 }
 
-// loadInventory loads the inventory data.
+// loadInventory loads the inventory data (read-only fetch; applied in Update).
 func (a *App) loadInventory() tea.Cmd {
+	filter, page, needCats := a.inventoryView.QueryParams()
+	svc := a.resourceSvc
 	return func() tea.Msg {
-		err := a.inventoryView.Load(context.Background())
-		return inventoryLoadedMsg{err: err}
+		var cats []*models.ResourceCategory
+		if needCats {
+			cats, _ = svc.ListCategories(context.Background())
+		}
+		result, err := svc.ListStocks(context.Background(), filter, page)
+		return inventoryLoadedMsg{categories: cats, result: result, err: err}
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -95,10 +95,15 @@ type App struct {
 	searchMode     bool // Search input mode
 	searchInput    string
 
-	// Alerts
-	alerts     []Alert
-	alertIndex int
-	alertTick  int
+	// Alerts. The displayed list (alerts) is rebuilt from two sources: alerts
+	// the UI raises directly (userAlerts, e.g. action confirmations) and alerts
+	// derived from the control core's live state (engineAlerts). Keeping them
+	// separate means live syncing never discards operator feedback.
+	alerts       []Alert
+	userAlerts   []Alert
+	engineAlerts []Alert
+	alertIndex   int
+	alertTick    int
 
 	// Population count (updated periodically)
 	population int
@@ -432,6 +437,7 @@ func (a *App) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// In kiosk mode the exhibit cannot be closed by visitors; only an
 		// operator at the console (Ctrl+C) may exit.
 		if a.kiosk && msg.String() != "ctrl+c" {
+			a.AddAlert(AlertInfo, "Kiosk mode active — exit is disabled")
 			return a, nil
 		}
 		a.showConfirm = true
@@ -548,24 +554,27 @@ func (a *App) handleSimulationKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // stepSim advances the simulation by the given number of hours off the UI
-// goroutine and reports completion.
+// goroutine and reports completion. The engine reference is captured on the UI
+// goroutine so the background closure does not read the mutable a.engine field.
 func (a *App) stepSim(hours int) tea.Cmd {
+	engine := a.engine
 	return func() tea.Msg {
-		if a.engine == nil {
+		if engine == nil {
 			return simSteppedMsg{}
 		}
-		err := a.engine.Step(context.Background(), hours)
+		err := engine.Step(context.Background(), hours)
 		return simSteppedMsg{err: err}
 	}
 }
 
 // snapshotSim captures a vault snapshot off the UI goroutine.
 func (a *App) snapshotSim() tea.Cmd {
+	engine := a.engine
 	return func() tea.Msg {
-		if a.engine == nil {
+		if engine == nil {
 			return snapshotMsg{err: fmt.Errorf("no simulation core attached")}
 		}
-		path, err := a.engine.CreateSnapshot(context.Background())
+		path, err := engine.CreateSnapshot(context.Background())
 		return snapshotMsg{path: path, err: err}
 	}
 }
@@ -1820,27 +1829,38 @@ func (a *App) renderFooter() string {
 	return separator + "\n" + a.theme.Footer.Render(help)
 }
 
-// AddAlert adds a new alert to the display.
+// AddAlert raises a UI alert (e.g. an action confirmation or warning).
 func (a *App) AddAlert(level AlertLevel, message string) {
-	a.alerts = append([]Alert{{
+	a.userAlerts = append([]Alert{{
 		Level:   level,
 		Message: message,
 		Time:    time.Now(),
-	}}, a.alerts...)
+	}}, a.userAlerts...)
 
-	// Keep only last 10 alerts
-	if len(a.alerts) > 10 {
-		a.alerts = a.alerts[:10]
+	// Keep only the most recent user alerts.
+	if len(a.userAlerts) > 10 {
+		a.userAlerts = a.userAlerts[:10]
 	}
 
-	// Reset alert rotation to show new alert
+	a.rebuildAlerts()
+	a.alertIndex = 0 // surface the new alert immediately
+}
+
+// ClearAlerts removes all alerts (both UI and engine-derived).
+func (a *App) ClearAlerts() {
+	a.userAlerts = nil
+	a.engineAlerts = nil
+	a.alerts = nil
 	a.alertIndex = 0
 }
 
-// ClearAlerts removes all alerts.
-func (a *App) ClearAlerts() {
-	a.alerts = []Alert{}
-	a.alertIndex = 0
+// rebuildAlerts recomputes the displayed alert list from the two sources,
+// UI-raised alerts first.
+func (a *App) rebuildAlerts() {
+	a.alerts = append(append([]Alert{}, a.userAlerts...), a.engineAlerts...)
+	if a.alertIndex >= len(a.alerts) {
+		a.alertIndex = 0
+	}
 }
 
 // renderSimulation renders the simulation control core console.
@@ -1875,10 +1895,8 @@ func (a *App) syncAlertsFromEngine() {
 		}
 		out = append(out, Alert{Level: level, Message: al.Message, Time: al.Raised})
 	}
-	a.alerts = out
-	if a.alertIndex >= len(a.alerts) {
-		a.alertIndex = 0
-	}
+	a.engineAlerts = out
+	a.rebuildAlerts()
 }
 
 // updateAttract engages or advances unattended attract (kiosk) mode based on

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -11,12 +11,15 @@ import (
 	"github.com/vtuos/vtuos/internal/config"
 	"github.com/vtuos/vtuos/internal/database"
 	"github.com/vtuos/vtuos/internal/models"
+	"github.com/vtuos/vtuos/internal/protocol"
 	"github.com/vtuos/vtuos/internal/services/facilities"
 	"github.com/vtuos/vtuos/internal/services/population"
 	"github.com/vtuos/vtuos/internal/services/resources"
+	"github.com/vtuos/vtuos/internal/simulation"
 	facviews "github.com/vtuos/vtuos/internal/tui/views/facilities"
 	popviews "github.com/vtuos/vtuos/internal/tui/views/population"
 	resviews "github.com/vtuos/vtuos/internal/tui/views/resources"
+	simviews "github.com/vtuos/vtuos/internal/tui/views/simulation"
 	"github.com/vtuos/vtuos/internal/util"
 )
 
@@ -41,9 +44,16 @@ const (
 	ModuleMedical    Module = "medical"
 	ModuleSecurity   Module = "security"
 	ModuleGovernance Module = "governance"
+	ModuleSimulation Module = "simulation"
 	ModuleSettings   Module = "settings"
 	ModuleHelp       Module = "help"
 )
+
+// attractRotation is the sequence of modules cycled through in attract mode.
+var attractRotation = []Module{
+	ModuleDashboard, ModuleSimulation, ModulePopulation, ModuleResources,
+	ModuleFacilities, ModuleLabor, ModuleMedical, ModuleSecurity, ModuleGovernance,
+}
 
 // App is the main Bubble Tea application model.
 type App struct {
@@ -57,11 +67,16 @@ type App struct {
 	resourceSvc   *resources.Service
 	facilitySvc   *facilities.Service
 
+	// Simulation control core (optional; live data when attached)
+	engine *simulation.Engine
+	live   protocol.VaultState
+
 	// Views
 	censusView    *popviews.CensusView
 	residentForm  *popviews.ResidentForm
 	inventoryView *resviews.InventoryView
 	systemsView   *facviews.SystemsView
+	simView       *simviews.ControlView
 
 	// UI state
 	theme       *Theme
@@ -87,6 +102,14 @@ type App struct {
 
 	// Population count (updated periodically)
 	population int
+
+	// Exhibit presentation state
+	booting       bool
+	bootStart     time.Time
+	kiosk         bool
+	attractActive bool
+	lastInputAt   time.Time
+	attractAt     time.Time
 }
 
 // Alert represents a system alert.
@@ -131,6 +154,7 @@ func New(db *database.DB, cfg *config.Config, clock *util.VaultClock) *App {
 	systemsView := facviews.NewSystemsView(facSvc)
 	systemsView.SetVaultTime(clock.Now())
 
+	now := time.Now()
 	return &App{
 		db:            db,
 		config:        cfg,
@@ -141,20 +165,44 @@ func New(db *database.DB, cfg *config.Config, clock *util.VaultClock) *App {
 		censusView:    censusView,
 		inventoryView: inventoryView,
 		systemsView:   systemsView,
+		simView:       simviews.NewControlView(),
 		theme:         NewTheme(cfg.Display.ColorScheme),
 		keys:          DefaultKeyMap(),
 		currentModule: ModuleDashboard,
 		alerts:        []Alert{},
+		booting:       cfg.Exhibit.BootSequence,
+		bootStart:     now,
+		kiosk:         cfg.Exhibit.Kiosk,
+		lastInputAt:   now,
+		attractAt:     now,
 	}
 }
 
+// AttachEngine binds a running simulation control core to the application so the
+// dashboard and simulation views render live operational state. When no engine
+// is attached the views fall back to static summaries.
+func (a *App) AttachEngine(e *simulation.Engine) {
+	a.engine = e
+	if e != nil {
+		a.live = e.Snapshot()
+	}
+}
+
+// bootDuration is how long the startup boot sequence plays before auto-continuing.
+const bootDuration = 3500 * time.Millisecond
+
 // Init implements tea.Model.
 func (a *App) Init() tea.Cmd {
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		tea.EnterAltScreen,
 		tickCmd(),
 		a.loadPopulation(),
-	)
+	}
+	if a.booting {
+		a.bootStart = time.Now()
+		cmds = append(cmds, bootTickCmd())
+	}
+	return tea.Batch(cmds...)
 }
 
 // tickCmd returns a command that sends tick messages.
@@ -162,6 +210,22 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
+}
+
+// bootTickCmd drives the boot sequence animation while booting.
+func bootTickCmd() tea.Cmd {
+	return tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg {
+		return bootTickMsg{}
+	})
+}
+
+type bootTickMsg struct{}
+
+type simSteppedMsg struct{ err error }
+
+type snapshotMsg struct {
+	path string
+	err  error
 }
 
 // loadPopulation loads the population count from the database.
@@ -214,6 +278,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.censusView.SetVaultTime(a.clock.Now())
 		a.inventoryView.SetVaultTime(a.clock.Now())
 		a.systemsView.SetVaultTime(a.clock.Now())
+		// Refresh live operational state from the control core.
+		if a.engine != nil {
+			a.live = a.engine.Snapshot()
+			a.syncAlertsFromEngine()
+		}
+		a.updateAttract()
 		// Rotate alerts every 3 ticks
 		a.alertTick++
 		if a.alertTick >= 3 && len(a.alerts) > 1 {
@@ -221,6 +291,34 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.alertIndex = (a.alertIndex + 1) % len(a.alerts)
 		}
 		return a, tickCmd()
+
+	case bootTickMsg:
+		if !a.booting {
+			return a, nil
+		}
+		if time.Since(a.bootStart) >= bootDuration {
+			a.booting = false
+			return a, nil
+		}
+		return a, bootTickCmd()
+
+	case simSteppedMsg:
+		if a.engine != nil {
+			a.live = a.engine.Snapshot()
+			a.syncAlertsFromEngine()
+		}
+		if msg.err != nil {
+			a.AddAlert(AlertWarning, "Simulation step failed: "+msg.err.Error())
+		}
+		return a, a.loadPopulation()
+
+	case snapshotMsg:
+		if msg.err != nil {
+			a.AddAlert(AlertWarning, "Snapshot failed: "+msg.err.Error())
+		} else {
+			a.AddAlert(AlertInfo, "Vault snapshot saved: "+msg.path)
+		}
+		return a, nil
 
 	case populationMsg:
 		a.population = msg.count
@@ -294,6 +392,18 @@ func (a *App) updateViewDimensions() {
 
 // handleKeyPress processes key press events.
 func (a *App) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Any key press is operator activity: dismiss the boot screen and exit
+	// attract (kiosk) mode without acting on the key itself.
+	a.lastInputAt = time.Now()
+	if a.booting {
+		a.booting = false
+		return a, nil
+	}
+	if a.attractActive {
+		a.attractActive = false
+		return a, nil
+	}
+
 	// Handle quit confirmation first (modal takes priority)
 	if a.showConfirm {
 		switch msg.String() {
@@ -319,6 +429,11 @@ func (a *App) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Global key bindings (only when not in input mode)
 	if a.keys.IsQuit(msg) {
+		// In kiosk mode the exhibit cannot be closed by visitors; only an
+		// operator at the console (Ctrl+C) may exit.
+		if a.kiosk && msg.String() != "ctrl+c" {
+			return a, nil
+		}
 		a.showConfirm = true
 		return a, nil
 	}
@@ -328,7 +443,12 @@ func (a *App) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		module := a.keys.GetFunctionKeyModule(msg)
 		switch module {
 		case "quit":
-			a.showConfirm = true
+			if !a.kiosk {
+				a.showConfirm = true
+			}
+		case "simulation":
+			a.currentModule = ModuleSimulation
+			a.showDetail = false
 		case "help":
 			a.previousModule = a.currentModule
 			a.currentModule = ModuleHelp
@@ -385,7 +505,90 @@ func (a *App) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a.handleFacilityKeys(msg)
 	}
 
+	if a.currentModule == ModuleSimulation {
+		return a.handleSimulationKeys(msg)
+	}
+
 	return a, nil
+}
+
+// handleSimulationKeys routes operator controls to the simulation control core.
+func (a *App) handleSimulationKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if a.engine == nil {
+		return a, nil
+	}
+	switch msg.String() {
+	case " ", "p":
+		if a.engine.Status() == protocol.SimRunning {
+			a.engine.Pause()
+		} else {
+			a.engine.Resume()
+		}
+		a.live = a.engine.Snapshot()
+	case "+", "=":
+		_ = a.engine.SetTimeScale(nextScaleUp(a.clock.TimeScale()))
+		a.live = a.engine.Snapshot()
+	case "-", "_":
+		_ = a.engine.SetTimeScale(nextScaleDown(a.clock.TimeScale()))
+		a.live = a.engine.Snapshot()
+	case "s":
+		return a, a.stepSim(24)
+	case "h":
+		return a, a.stepSim(1)
+	case "k":
+		return a, a.snapshotSim()
+	case "a":
+		for _, al := range a.live.Alerts {
+			a.engine.AcknowledgeAlert(al.Code)
+		}
+		a.live = a.engine.Snapshot()
+		a.syncAlertsFromEngine()
+	}
+	return a, nil
+}
+
+// stepSim advances the simulation by the given number of hours off the UI
+// goroutine and reports completion.
+func (a *App) stepSim(hours int) tea.Cmd {
+	return func() tea.Msg {
+		if a.engine == nil {
+			return simSteppedMsg{}
+		}
+		err := a.engine.Step(context.Background(), hours)
+		return simSteppedMsg{err: err}
+	}
+}
+
+// snapshotSim captures a vault snapshot off the UI goroutine.
+func (a *App) snapshotSim() tea.Cmd {
+	return func() tea.Msg {
+		if a.engine == nil {
+			return snapshotMsg{err: fmt.Errorf("no simulation core attached")}
+		}
+		path, err := a.engine.CreateSnapshot(context.Background())
+		return snapshotMsg{path: path, err: err}
+	}
+}
+
+// scaleLadder is the set of time scales cycled through with +/- in the control view.
+var scaleLadder = []float64{1, 60, 600, 1440, 3600, 14400, 86400}
+
+func nextScaleUp(cur float64) float64 {
+	for _, s := range scaleLadder {
+		if s > cur+0.001 {
+			return s
+		}
+	}
+	return scaleLadder[len(scaleLadder)-1]
+}
+
+func nextScaleDown(cur float64) float64 {
+	for i := len(scaleLadder) - 1; i >= 0; i-- {
+		if scaleLadder[i] < cur-0.001 {
+			return scaleLadder[i]
+		}
+	}
+	return scaleLadder[0]
 }
 
 // handlePopulationKeys handles key presses in the population module.
@@ -704,6 +907,10 @@ func (a *App) View() string {
 		return a.theme.Title.Render("Vault-Tec Unified Operating System shutting down...")
 	}
 
+	if a.booting {
+		return a.renderBoot()
+	}
+
 	var b strings.Builder
 
 	// Header
@@ -851,6 +1058,8 @@ func (a *App) getModuleContent() string {
 		return a.renderSecurity()
 	case ModuleGovernance:
 		return a.renderGovernance()
+	case ModuleSimulation:
+		return a.renderSimulation()
 	case ModuleHelp:
 		return a.renderHelp()
 	default:
@@ -942,10 +1151,16 @@ func (a *App) renderPopulationPanel(totalWidth int, bp LayoutBreakpoint) string 
 	b.WriteString("\n")
 
 	capacity := a.config.Vault.DesignedCapacity
-	ratio := float64(a.population) / float64(capacity)
+	active := a.activePopulation()
+	ratio := float64(active) / float64(capacity)
 
-	b.WriteString(fmt.Sprintf("  Active:   %s\n", a.theme.Value.Render(fmt.Sprintf("%d", a.population))))
+	b.WriteString(fmt.Sprintf("  Active:   %s\n", a.theme.Value.Render(fmt.Sprintf("%d", active))))
 	b.WriteString(fmt.Sprintf("  Capacity: %s\n", a.theme.Muted.Render(fmt.Sprintf("%d", capacity))))
+	if a.hasLive() {
+		b.WriteString(fmt.Sprintf("  Births:   %s   Deaths: %s\n",
+			a.theme.Success.Render(fmt.Sprintf("%d", a.live.Population.Births)),
+			a.theme.Error.Render(fmt.Sprintf("%d", a.live.Population.Deaths))))
+	}
 
 	// Population bar
 	barWidth := totalWidth/2 - 4
@@ -959,7 +1174,7 @@ func (a *App) renderPopulationPanel(totalWidth int, bp LayoutBreakpoint) string 
 		barWidth = 10
 	}
 	b.WriteString("  ")
-	b.WriteString(a.theme.ProgressBar(float64(a.population), float64(capacity), barWidth))
+	b.WriteString(a.theme.ProgressBar(float64(active), float64(capacity), barWidth))
 	pctStr := fmt.Sprintf(" %.0f%%", ratio*100)
 	b.WriteString(a.theme.Muted.Render(pctStr))
 	b.WriteString("\n")
@@ -973,20 +1188,37 @@ func (a *App) renderSystemsPanel(totalWidth int, bp LayoutBreakpoint) string {
 	b.WriteString(a.theme.Subtitle.Render("CRITICAL SYSTEMS"))
 	b.WriteString("\n")
 
-	systems := []struct {
-		name   string
-		status string
-		pct    float64
-	}{
-		{"Power", "OPERATIONAL", 0.98},
-		{"Water", "OPERATIONAL", 0.95},
-		{"HVAC", "OPERATIONAL", 0.92},
-		{"Security", "OPERATIONAL", 1.0},
-	}
-
 	barWidth := 16
 	if bp == BreakpointNarrow {
 		barWidth = 10
+	}
+
+	type sysRow struct {
+		name   string
+		status string
+		pct    float64
+	}
+	var systems []sysRow
+
+	if a.hasLive() {
+		for _, s := range a.live.SystemList {
+			if !s.Critical {
+				continue
+			}
+			systems = append(systems, sysRow{name: shortSystemName(s.Name), status: s.Status, pct: s.Efficiency / 100.0})
+			if len(systems) >= 5 {
+				break
+			}
+		}
+	}
+	if len(systems) == 0 {
+		// Fallback summary when no live core is attached.
+		systems = []sysRow{
+			{"Power", "OPERATIONAL", 0.98},
+			{"Water", "OPERATIONAL", 0.95},
+			{"HVAC", "OPERATIONAL", 0.92},
+			{"Security", "OPERATIONAL", 1.0},
+		}
 	}
 
 	for _, sys := range systems {
@@ -998,7 +1230,7 @@ func (a *App) renderSystemsPanel(totalWidth int, bp LayoutBreakpoint) string {
 			statusStyle = a.theme.Error
 		}
 
-		line := fmt.Sprintf("  %-10s", sys.name)
+		line := fmt.Sprintf("  %-12s", sys.name)
 		b.WriteString(a.theme.Base.Render(line))
 		b.WriteString(a.theme.ProgressBar(sys.pct, 1.0, barWidth))
 		b.WriteString(" ")
@@ -1009,34 +1241,60 @@ func (a *App) renderSystemsPanel(totalWidth int, bp LayoutBreakpoint) string {
 	return b.String()
 }
 
+// shortSystemName trims a system name to fit the dashboard column.
+func shortSystemName(name string) string {
+	if len(name) <= 12 {
+		return name
+	}
+	return name[:11] + "…"
+}
+
 // renderResourcesPanel renders resource status for the dashboard.
 func (a *App) renderResourcesPanel(totalWidth int, bp LayoutBreakpoint) string {
 	var b strings.Builder
 	b.WriteString(a.theme.Subtitle.Render("RESOURCE STATUS"))
 	b.WriteString("\n")
 
-	// Placeholder resource data (would come from service in production)
-	resourceStats := []struct {
-		name    string
-		pct     float64
-		runway  int
-	}{
-		{"Food", 0.72, 180},
-		{"Water", 0.85, 240},
-		{"Medical", 0.60, 120},
-		{"Power", 0.90, 365},
-	}
-
 	barWidth := 16
 	if bp == BreakpointNarrow {
 		barWidth = 10
 	}
 
+	type resRow struct {
+		name   string
+		pct    float64
+		runway int
+	}
+	var resourceStats []resRow
+
+	if a.hasLive() {
+		for _, r := range a.live.Resources {
+			if r.DailyUse <= 0 {
+				continue
+			}
+			resourceStats = append(resourceStats, resRow{name: r.Label, pct: r.FillFraction, runway: r.RunwayDays})
+			if len(resourceStats) >= 5 {
+				break
+			}
+		}
+	}
+	if len(resourceStats) == 0 {
+		resourceStats = []resRow{
+			{"Food", 0.72, 180},
+			{"Water", 0.85, 240},
+			{"Medical", 0.60, 120},
+			{"Power", 0.90, 365},
+		}
+	}
+
 	for _, res := range resourceStats {
-		line := fmt.Sprintf("  %-10s", res.name)
+		line := fmt.Sprintf("  %-12s", shortSystemName(res.name))
 		b.WriteString(a.theme.Base.Render(line))
 		b.WriteString(a.theme.ProgressBar(res.pct, 1.0, barWidth))
-		runway := fmt.Sprintf(" %dd", res.runway)
+		runway := "  ∞"
+		if res.runway >= 0 {
+			runway = fmt.Sprintf(" %dd", res.runway)
+		}
 		b.WriteString(a.theme.Muted.Render(runway))
 		b.WriteString("\n")
 	}
@@ -1062,6 +1320,16 @@ func (a *App) renderSimulationPanel(totalWidth int, bp LayoutBreakpoint) string 
 		status = "PAUSED"
 		statusStyle = a.theme.Warning
 	}
+	if a.hasLive() {
+		switch a.live.Status {
+		case protocol.SimRunning:
+			status, statusStyle = "RUNNING", a.theme.Success
+		case protocol.SimPaused:
+			status, statusStyle = "PAUSED", a.theme.Warning
+		default:
+			status, statusStyle = "STOPPED", a.theme.Muted
+		}
+	}
 
 	vaultTime := a.clock.Now()
 	sealDate, err := a.config.Simulation.StartDateTime()
@@ -1076,8 +1344,34 @@ func (a *App) renderSimulationPanel(totalWidth int, bp LayoutBreakpoint) string 
 	b.WriteString(fmt.Sprintf("  Time Scale: %s\n", a.theme.Value.Render(fmt.Sprintf("%.0fx", a.clock.TimeScale()))))
 	b.WriteString(fmt.Sprintf("  Vault Time: %s\n", a.theme.Value.Render(vaultTime.Format("2006-01-02 15:04"))))
 	b.WriteString(fmt.Sprintf("  Elapsed:    %s\n", a.theme.Value.Render(fmt.Sprintf("%d years, %d days", years, days))))
+	if a.hasLive() {
+		balStyle := a.theme.Success
+		if a.live.Power.BalanceKW < 0 {
+			balStyle = a.theme.Error
+		} else if a.live.Power.ReservePct < 10 {
+			balStyle = a.theme.Warning
+		}
+		b.WriteString(fmt.Sprintf("  Power Bal:  %s\n", balStyle.Render(fmt.Sprintf("%+.0f kW (%.0f%%)", a.live.Power.BalanceKW, a.live.Power.ReservePct))))
+		b.WriteString(fmt.Sprintf("  Ticks:      %s\n", a.theme.Value.Render(fmt.Sprintf("%d", a.live.TickCount))))
+		b.WriteString(a.theme.Muted.Render("  [F11] open control core"))
+		b.WriteString("\n")
+	}
 
 	return b.String()
+}
+
+// hasLive reports whether a live operational snapshot is available.
+func (a *App) hasLive() bool {
+	return a.engine != nil && a.live.SchemaVersion != ""
+}
+
+// activePopulation returns the authoritative active population: the live count
+// when a control core is attached, otherwise the periodically-loaded count.
+func (a *App) activePopulation() int {
+	if a.hasLive() {
+		return a.live.Population.Active
+	}
+	return a.population
 }
 
 // renderSideBySide renders two panels side by side, falling back to vertical stack.
@@ -1412,6 +1706,7 @@ func (a *App) renderHelp() string {
 		{"F7", "Medical Records"},
 		{"F8", "Security"},
 		{"F9", "Governance"},
+		{"F11", "Simulation Control"},
 		{"F10", "Quit"},
 	}
 
@@ -1515,6 +1810,10 @@ func (a *App) renderFooter() string {
 	// Draw separator
 	separator := a.theme.DrawHorizontalLine(a.width)
 
+	if a.attractActive {
+		return separator + "\n" + a.theme.Accent.Render("  ATTRACT MODE — press any key to take control")
+	}
+
 	// Help text adapts to width
 	help := a.keys.StatusBarHelpResponsive(a.width)
 
@@ -1544,9 +1843,141 @@ func (a *App) ClearAlerts() {
 	a.alertIndex = 0
 }
 
+// renderSimulation renders the simulation control core console.
+func (a *App) renderSimulation() string {
+	if a.engine == nil {
+		var b strings.Builder
+		b.WriteString(a.theme.Title.Render("═══ SIMULATION CONTROL CORE ═══"))
+		b.WriteString("\n\n")
+		b.WriteString(a.theme.Muted.Render("  The simulation control core is not attached in this mode."))
+		b.WriteString("\n")
+		b.WriteString(a.theme.Muted.Render("  Run the local console or master server to drive vault operations."))
+		return b.String()
+	}
+	h := ContentHeight(a.height, chromeLines)
+	return a.simView.Render(themeStyler{a.theme}, a.live, a.engine.Events(12), a.engine.Alerts(), a.width, h)
+}
+
+// syncAlertsFromEngine mirrors the control core's active alerts into the header
+// alert bar so operational conditions surface across every view.
+func (a *App) syncAlertsFromEngine() {
+	var out []Alert
+	for _, al := range a.live.Alerts {
+		if al.Acknowledged {
+			continue
+		}
+		level := AlertInfo
+		switch al.Level {
+		case protocol.AlertCritical:
+			level = AlertCritical
+		case protocol.AlertWarning:
+			level = AlertWarning
+		}
+		out = append(out, Alert{Level: level, Message: al.Message, Time: al.Raised})
+	}
+	a.alerts = out
+	if a.alertIndex >= len(a.alerts) {
+		a.alertIndex = 0
+	}
+}
+
+// updateAttract engages or advances unattended attract (kiosk) mode based on
+// operator idle time.
+func (a *App) updateAttract() {
+	if a.booting || !a.config.Exhibit.AttractMode {
+		return
+	}
+	idle := time.Duration(a.config.Exhibit.AttractIdleSeconds) * time.Second
+	if idle <= 0 {
+		idle = 120 * time.Second
+	}
+	if !a.attractActive {
+		if time.Since(a.lastInputAt) >= idle {
+			a.attractActive = true
+			a.attractAt = time.Now()
+			a.currentModule = ModuleDashboard
+			a.showDetail = false
+		}
+		return
+	}
+	rotate := time.Duration(a.config.Exhibit.RotateSeconds) * time.Second
+	if rotate <= 0 {
+		rotate = 12 * time.Second
+	}
+	if time.Since(a.attractAt) >= rotate {
+		a.attractAt = time.Now()
+		a.currentModule = nextAttractModule(a.currentModule)
+		a.showDetail = false
+	}
+}
+
+func nextAttractModule(cur Module) Module {
+	for i, m := range attractRotation {
+		if m == cur {
+			return attractRotation[(i+1)%len(attractRotation)]
+		}
+	}
+	return attractRotation[0]
+}
+
+// renderBoot renders a RobCo-style startup sequence that reveals progressively.
+func (a *App) renderBoot() string {
+	lines := []string{
+		"ROBCO INDUSTRIES (TM) TERMLINK PROTOCOL",
+		"VAULT-TEC UNIFIED OPERATING SYSTEM " + Version,
+		"COPYRIGHT 2075-2077 VAULT-TEC CORP.",
+		"",
+		"> ESTABLISH UPLINK..................... OK",
+		"> MOUNT VAULT DATABASE................. OK",
+		"> VERIFY SCHEMA INTEGRITY............. OK",
+		"> LOAD POPULATION REGISTRY............ OK",
+		"> CALIBRATE LIFE SUPPORT MONITORS.... OK",
+		"> SPIN UP SIMULATION CONTROL CORE.... ONLINE",
+		"",
+		"VAULT OPERATIONS NOMINAL. WELCOME, OVERSEER.",
+	}
+
+	revealInterval := 220 * time.Millisecond
+	revealed := int(time.Since(a.bootStart)/revealInterval) + 1
+	if revealed > len(lines) {
+		revealed = len(lines)
+	}
+
+	var b strings.Builder
+	b.WriteString("\n\n")
+	for i := 0; i < revealed; i++ {
+		line := lines[i]
+		switch {
+		case strings.HasSuffix(line, "OK"):
+			b.WriteString("  " + a.theme.Success.Render(line))
+		case strings.HasSuffix(line, "ONLINE"):
+			b.WriteString("  " + a.theme.Accent.Render(line))
+		case i < 3:
+			b.WriteString("  " + a.theme.Primary.Render(line))
+		default:
+			b.WriteString("  " + a.theme.Base.Render(line))
+		}
+		b.WriteString("\n")
+	}
+	if revealed >= len(lines) {
+		b.WriteString("\n  " + a.theme.Muted.Render("PRESS ANY KEY TO CONTINUE") + a.theme.Accent.Render(" █"))
+	}
+
+	// Center vertically within the available height.
+	style := lipgloss.NewStyle().Width(a.width).Height(a.height).Align(lipgloss.Left, lipgloss.Center)
+	return style.Render(b.String())
+}
+
 // Run starts the TUI application.
 func Run(ctx context.Context, db *database.DB, cfg *config.Config, clock *util.VaultClock) error {
+	return RunWithEngine(ctx, db, cfg, clock, nil)
+}
+
+// RunWithEngine starts the TUI application with an attached simulation control
+// core so views render live operational state.
+func RunWithEngine(ctx context.Context, db *database.DB, cfg *config.Config, clock *util.VaultClock, engine *simulation.Engine) error {
 	app := New(db, cfg, clock)
+	app.AttachEngine(engine)
 
 	p := tea.NewProgram(app, tea.WithAltScreen())
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -34,6 +34,7 @@ type KeyMap struct {
 	F8  Key
 	F9  Key
 	F10 Key
+	F11 Key
 
 	// Form navigation
 	Tab      Key
@@ -176,6 +177,11 @@ func DefaultKeyMap() KeyMap {
 			Help:    "Quit",
 			Enabled: true,
 		},
+		F11: Key{
+			Keys:    []string{"f11"},
+			Help:    "Simulation",
+			Enabled: true,
+		},
 
 		// Form navigation
 		Tab: Key{
@@ -252,7 +258,7 @@ func (km KeyMap) IsNavigation(msg tea.KeyMsg) bool {
 // IsFunctionKey checks if the key message is a function key.
 func (km KeyMap) IsFunctionKey(msg tea.KeyMsg) bool {
 	return MatchesAny(msg, km.F1, km.F2, km.F3, km.F4, km.F5,
-		km.F6, km.F7, km.F8, km.F9, km.F10)
+		km.F6, km.F7, km.F8, km.F9, km.F10, km.F11)
 }
 
 // GetFunctionKeyModule returns the module name for a function key.
@@ -278,6 +284,8 @@ func (km KeyMap) GetFunctionKeyModule(msg tea.KeyMsg) string {
 		return "governance"
 	case km.F10.Matches(msg):
 		return "quit"
+	case km.F11.Matches(msg):
+		return "simulation"
 	default:
 		return ""
 	}
@@ -296,6 +304,6 @@ func (km KeyMap) StatusBarHelpResponsive(width int) string {
 	case width < 100:
 		return "[F1]Help [F2]Dashboard [F3]Population [F4]Resources [F10]Quit"
 	default:
-		return "[F1]Help [F2]Dashboard [F3]Population [F4]Resources [F5]Facilities [F6]Labor [F7]Medical [F8]Security [F9]Governance [F10]Quit"
+		return "[F1]Help [F2]Dashboard [F3]Population [F4]Resources [F5]Facilities [F6]Labor [F7]Medical [F8]Security [F9]Governance [F11]Sim [F10]Quit"
 	}
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -135,7 +135,7 @@ func (t *Theme) Panel(title, content string, width int) string {
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.SecondaryColor).
-		Width(width - 2). // -2 for border chars
+		Width(width-2). // -2 for border chars
 		Padding(0, 1)
 
 	rendered := style.Render(content)

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -131,12 +131,12 @@ func TestTruncate(t *testing.T) {
 		maxWidth int
 		expected string
 	}{
-		{"hello", 10, "hello"},       // fits
-		{"hello", 5, "hello"},        // exact fit
-		{"hello world", 5, "hell…"},  // truncated
-		{"hi", 0, ""},                // zero width
-		{"hello world", 3, "hel"},    // very short (<=3)
-		{"hello world", 1, "h"},      // single char
+		{"hello", 10, "hello"},      // fits
+		{"hello", 5, "hello"},       // exact fit
+		{"hello world", 5, "hell…"}, // truncated
+		{"hi", 0, ""},               // zero width
+		{"hello world", 3, "hel"},   // very short (<=3)
+		{"hello world", 1, "h"},     // single char
 	}
 
 	for _, tt := range tests {
@@ -154,8 +154,8 @@ func TestPadRight(t *testing.T) {
 		expected string
 	}{
 		{"hi", 5, "hi   "},
-		{"hello", 5, "hello"},     // exact fit
-		{"hello!", 5, "hello!"},   // already wider
+		{"hello", 5, "hello"},   // exact fit
+		{"hello!", 5, "hello!"}, // already wider
 	}
 
 	for _, tt := range tests {
@@ -173,8 +173,8 @@ func TestPadLeft(t *testing.T) {
 		expected string
 	}{
 		{"hi", 5, "   hi"},
-		{"hello", 5, "hello"},     // exact fit
-		{"hello!", 5, "hello!"},   // already wider
+		{"hello", 5, "hello"},   // exact fit
+		{"hello!", 5, "hello!"}, // already wider
 	}
 
 	for _, tt := range tests {
@@ -213,10 +213,10 @@ func TestContentHeight(t *testing.T) {
 		chromeLines int
 		expected    int
 	}{
-		{24, 6, 18},  // normal
-		{40, 6, 34},  // tall terminal
-		{8, 6, 5},    // very short, clamps to 5
-		{5, 6, 5},    // shorter than chrome, clamps to 5
+		{24, 6, 18}, // normal
+		{40, 6, 34}, // tall terminal
+		{8, 6, 5},   // very short, clamps to 5
+		{5, 6, 5},   // shorter than chrome, clamps to 5
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/simadapter.go
+++ b/internal/tui/simadapter.go
@@ -1,0 +1,20 @@
+package tui
+
+// themeStyler adapts the TUI Theme to the minimal Styler interface required by
+// the simulation control view, keeping that view free of a dependency on this
+// package.
+type themeStyler struct{ t *Theme }
+
+func (s themeStyler) Title(x string) string    { return s.t.Title.Render(x) }
+func (s themeStyler) Subtitle(x string) string { return s.t.Subtitle.Render(x) }
+func (s themeStyler) Label(x string) string    { return s.t.Label.Render(x) }
+func (s themeStyler) Value(x string) string    { return s.t.Value.Render(x) }
+func (s themeStyler) Muted(x string) string    { return s.t.Muted.Render(x) }
+func (s themeStyler) Success(x string) string  { return s.t.Success.Render(x) }
+func (s themeStyler) Warning(x string) string  { return s.t.Warning.Render(x) }
+func (s themeStyler) Error(x string) string    { return s.t.Error.Render(x) }
+func (s themeStyler) Accent(x string) string   { return s.t.Accent.Render(x) }
+
+func (s themeStyler) Bar(value, max float64, width int) string {
+	return s.t.ProgressBar(value, max, width)
+}

--- a/internal/tui/views/facilities/systems.go
+++ b/internal/tui/views/facilities/systems.go
@@ -2,7 +2,6 @@
 package facilities
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -49,20 +48,22 @@ func NewSystemsView(service *facilities.Service) *SystemsView {
 	}
 }
 
-// Load fetches facility systems from the database.
-func (v *SystemsView) Load(ctx context.Context) error {
-	v.loading = true
-	v.err = nil
+// QueryParams returns a snapshot of the current query parameters. It is called
+// on the UI goroutine so the asynchronous load command can fetch without
+// touching view state concurrently.
+func (v *SystemsView) QueryParams() (models.FacilitySystemFilter, models.Pagination) {
+	return v.filter, v.page
+}
 
-	result, err := v.service.ListSystems(ctx, v.filter, v.page)
-	if err != nil {
-		v.loading = false
-		v.err = err
-		return err
-	}
-
-	v.systems = result.Systems
+// ApplySystems stores a fetched result and rebuilds the table. It must be called
+// on the UI goroutine (from Update), never from a command goroutine.
+func (v *SystemsView) ApplySystems(result *models.FacilitySystemList) {
 	v.loading = false
+	v.err = nil
+	if result == nil {
+		return
+	}
+	v.systems = result.Systems
 
 	rows := make([][]string, len(v.systems))
 	for i, s := range v.systems {
@@ -87,8 +88,12 @@ func (v *SystemsView) Load(ctx context.Context) error {
 
 	v.table.SetRows(rows)
 	v.table.SetPagination(result.Page, result.TotalPages, result.Total)
+}
 
-	return nil
+// SetLoadError records a failed load for display.
+func (v *SystemsView) SetLoadError(err error) {
+	v.loading = false
+	v.err = err
 }
 
 // SetVaultTime sets the current vault time for display.

--- a/internal/tui/views/population/census.go
+++ b/internal/tui/views/population/census.go
@@ -2,7 +2,6 @@
 package population
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -53,25 +52,25 @@ func NewCensusView(service *population.Service) *CensusView {
 	}
 }
 
-// Load fetches residents from the database.
-func (v *CensusView) Load(ctx context.Context) error {
-	v.loading = true
-	v.err = nil
+// QueryParams returns a snapshot of the current query parameters. It is called
+// on the UI goroutine so the asynchronous load command can fetch without
+// touching view state concurrently.
+func (v *CensusView) QueryParams() (models.ResidentFilter, models.Pagination) {
+	return v.filter, v.page
+}
 
-	result, err := v.service.ListResidents(ctx, v.filter, v.page)
-	if err != nil {
-		v.loading = false
-		v.err = err
-		return err
-	}
-
-	v.residents = result.Residents
+// ApplyResidents stores a fetched result and rebuilds the table. It must be
+// called on the UI goroutine (from Update), never from a command goroutine.
+func (v *CensusView) ApplyResidents(result *models.ResidentList) {
 	v.loading = false
+	v.err = nil
+	if result == nil {
+		return
+	}
+	v.residents = result.Residents
 
-	// Convert to table rows
 	rows := make([][]string, len(v.residents))
 	for i, r := range v.residents {
-		age := r.Age(v.vaultTime)
 		blood := string(r.BloodType)
 		if blood == "" {
 			blood = "-"
@@ -80,7 +79,7 @@ func (v *CensusView) Load(ctx context.Context) error {
 			r.RegistryNumber,
 			r.Surname,
 			r.GivenNames,
-			fmt.Sprintf("%d", age),
+			fmt.Sprintf("%d", r.Age(v.vaultTime)),
 			string(r.Sex),
 			blood,
 			string(r.Status),
@@ -91,8 +90,12 @@ func (v *CensusView) Load(ctx context.Context) error {
 
 	v.table.SetRows(rows)
 	v.table.SetPagination(result.Page, result.TotalPages, result.Total)
+}
 
-	return nil
+// SetLoadError records a failed load for display.
+func (v *CensusView) SetLoadError(err error) {
+	v.loading = false
+	v.err = err
 }
 
 // SetVaultTime sets the current vault time for age calculation.

--- a/internal/tui/views/resources/inventory.go
+++ b/internal/tui/views/resources/inventory.go
@@ -2,7 +2,6 @@
 package resources
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -54,43 +53,36 @@ func NewInventoryView(service *resources.Service) *InventoryView {
 	}
 }
 
-// Load fetches stocks from the database.
-func (v *InventoryView) Load(ctx context.Context) error {
-	v.loading = true
-	v.err = nil
-
-	// Load categories for display
-	if v.categories == nil {
-		cats, err := v.service.ListCategories(ctx)
-		if err == nil {
-			v.categories = cats
-		}
-	}
-
-	// Apply category filter if selected
+// QueryParams returns a snapshot of the current query parameters (with the
+// selected category folded into the filter) plus whether the category list
+// still needs to be fetched. It is called on the UI goroutine.
+func (v *InventoryView) QueryParams() (models.StockFilter, models.Pagination, bool) {
 	filter := v.filter
 	if v.selectedCategory != nil {
 		filter.CategoryID = *v.selectedCategory
 	}
+	return filter, v.page, v.categories == nil
+}
 
-	result, err := v.service.ListStocks(ctx, filter, v.page)
-	if err != nil {
-		v.loading = false
-		v.err = err
-		return err
-	}
-
-	v.stocks = result.Stocks
+// ApplyStocks stores a fetched result and rebuilds the table. When categories
+// are supplied they are cached. It must be called on the UI goroutine.
+func (v *InventoryView) ApplyStocks(categories []*models.ResourceCategory, result *models.StockList) {
 	v.loading = false
+	v.err = nil
+	if categories != nil {
+		v.categories = categories
+	}
+	if result == nil {
+		return
+	}
+	v.stocks = result.Stocks
 
-	// Convert to table rows
 	rows := make([][]string, len(v.stocks))
 	for i, s := range v.stocks {
 		catCode := "-"
 		if s.Item != nil && s.Item.Category != nil {
 			catCode = s.Item.Category.Code
 		} else if s.Item != nil {
-			// Try to find category from our cached list
 			for _, cat := range v.categories {
 				if cat.ID == s.Item.CategoryID {
 					catCode = cat.Code
@@ -135,8 +127,12 @@ func (v *InventoryView) Load(ctx context.Context) error {
 
 	v.table.SetRows(rows)
 	v.table.SetPagination(result.Page, result.TotalPages, result.Total)
+}
 
-	return nil
+// SetLoadError records a failed load for display.
+func (v *InventoryView) SetLoadError(err error) {
+	v.loading = false
+	v.err = err
 }
 
 // SetVaultTime sets the current vault time.

--- a/internal/tui/views/simulation/control.go
+++ b/internal/tui/views/simulation/control.go
@@ -1,0 +1,280 @@
+// Package simulation provides the operator control surface for the simulation
+// control core within the terminal UI. It is a render-only component: the host
+// application owns the engine and routes key presses to it, while this view
+// presents live operational telemetry, the event feed, and active alerts.
+package simulation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// Styler is the minimal styling surface this view needs from the host theme.
+// It is satisfied by the TUI theme, avoiding an import cycle.
+type Styler interface {
+	Title(string) string
+	Subtitle(string) string
+	Label(string) string
+	Value(string) string
+	Muted(string) string
+	Success(string) string
+	Warning(string) string
+	Error(string) string
+	Accent(string) string
+	Bar(value, max float64, width int) string
+}
+
+// ControlView renders the simulation control console.
+type ControlView struct{}
+
+// NewControlView constructs the control view.
+func NewControlView() *ControlView { return &ControlView{} }
+
+// Render draws the control console from the supplied operational snapshot,
+// recent events and active alerts.
+func (v *ControlView) Render(s Styler, st protocol.VaultState, events []protocol.EventRecord, alerts []protocol.Alert, width, height int) string {
+	if width < 20 {
+		width = 20
+	}
+	var b strings.Builder
+
+	b.WriteString(s.Title("═══ SIMULATION CONTROL CORE ═══"))
+	b.WriteString("\n\n")
+
+	// Status line.
+	statusStr := renderStatus(s, st.Status)
+	b.WriteString(fmt.Sprintf("  %s   %s   %s\n",
+		s.Label("STATUS:")+" "+statusStr,
+		s.Label("SCALE:")+" "+s.Value(formatScale(st.TimeScale)),
+		s.Label("TICK:")+" "+s.Value(fmt.Sprintf("%d", st.TickCount)),
+	))
+	b.WriteString(fmt.Sprintf("  %s %s    %s %s\n",
+		s.Label("VAULT TIME:"), s.Value(st.VaultTime.Format("2077-01-02 15:04")),
+		s.Label("ELAPSED:"), s.Value(fmt.Sprintf("%d years, %d days", st.ElapsedYears, st.ElapsedDays%365)),
+	))
+	b.WriteString("\n")
+
+	// Controls legend (operator actions handled by the host).
+	b.WriteString(s.Muted("  [Space] play/pause   [+/-] time scale   [s] step 1 day   [h] step 1 hour   [k] snapshot   [a] ack alerts"))
+	b.WriteString("\n\n")
+
+	// Two-column operational summary.
+	left := renderOpsSummary(s, st)
+	right := renderPower(s, st) + "\n" + renderResourceRunways(s, st)
+	b.WriteString(joinColumns(left, right, width))
+	b.WriteString("\n")
+
+	// Active alerts.
+	b.WriteString(s.Subtitle("ACTIVE ALERTS"))
+	b.WriteString("\n")
+	if len(alerts) == 0 {
+		b.WriteString(s.Success("  ✓ No active alerts — all systems nominal"))
+		b.WriteString("\n")
+	} else {
+		shown := alerts
+		if len(shown) > 5 {
+			shown = shown[:5]
+		}
+		for _, a := range shown {
+			b.WriteString("  " + renderAlertLine(s, a) + "\n")
+		}
+	}
+	b.WriteString("\n")
+
+	// Operational event feed.
+	b.WriteString(s.Subtitle("OPERATIONAL EVENT LOG"))
+	b.WriteString("\n")
+	if len(events) == 0 {
+		b.WriteString(s.Muted("  No events recorded yet. Advance time to begin operations."))
+		b.WriteString("\n")
+	} else {
+		max := 8
+		if max > len(events) {
+			max = len(events)
+		}
+		for i := 0; i < max; i++ {
+			b.WriteString("  " + renderEventLine(s, events[i], width-4) + "\n")
+		}
+	}
+
+	return b.String()
+}
+
+func renderStatus(s Styler, st protocol.SimStatus) string {
+	switch st {
+	case protocol.SimRunning:
+		return s.Success("● RUNNING")
+	case protocol.SimPaused:
+		return s.Warning("‖ PAUSED")
+	default:
+		return s.Muted("■ STOPPED")
+	}
+}
+
+func renderOpsSummary(s Styler, st protocol.VaultState) string {
+	var b strings.Builder
+	b.WriteString(s.Subtitle("POPULATION & SYSTEMS"))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Active:      %s / %s  (%.0f%%)\n",
+		s.Value(fmt.Sprintf("%d", st.Population.Active)),
+		s.Muted(fmt.Sprintf("%d", st.Population.Capacity)),
+		st.Population.LoadPct))
+	b.WriteString(fmt.Sprintf("  Births/Deaths: %s / %s\n",
+		s.Success(fmt.Sprintf("%d", st.Population.Births)),
+		s.Error(fmt.Sprintf("%d", st.Population.Deaths))))
+	if st.Population.Quarantined > 0 {
+		b.WriteString(fmt.Sprintf("  Quarantine:  %s\n", s.Warning(fmt.Sprintf("%d", st.Population.Quarantined))))
+	}
+	b.WriteString(fmt.Sprintf("  Avg Age:     %s\n", s.Value(fmt.Sprintf("%.1f", st.Population.AverageAge))))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Systems:     %s op  %s deg  %s fail\n",
+		s.Success(fmt.Sprintf("%d", st.Systems.Operational)),
+		s.Warning(fmt.Sprintf("%d", st.Systems.Degraded)),
+		s.Error(fmt.Sprintf("%d", st.Systems.Failed))))
+	b.WriteString(fmt.Sprintf("  Avg Eff:     %s  ",
+		s.Value(fmt.Sprintf("%.0f%%", st.Systems.AvgEfficiency))))
+	b.WriteString(s.Bar(st.Systems.AvgEfficiency, 100, 16))
+	b.WriteString("\n")
+	if st.Systems.OverdueMaint > 0 {
+		b.WriteString(fmt.Sprintf("  Overdue PM:  %s\n", s.Warning(fmt.Sprintf("%d", st.Systems.OverdueMaint))))
+	}
+	return b.String()
+}
+
+func renderPower(s Styler, st protocol.VaultState) string {
+	var b strings.Builder
+	b.WriteString(s.Subtitle("POWER BALANCE"))
+	b.WriteString("\n")
+	balStyle := s.Success
+	if st.Power.BalanceKW < 0 {
+		balStyle = s.Error
+	} else if st.Power.ReservePct < 10 {
+		balStyle = s.Warning
+	}
+	b.WriteString(fmt.Sprintf("  Gen: %s kW   Load: %s kW\n",
+		s.Value(fmt.Sprintf("%.0f", st.Power.GenerationKW)),
+		s.Value(fmt.Sprintf("%.0f", st.Power.ConsumptionKW))))
+	b.WriteString(fmt.Sprintf("  Balance: %s kW  (reserve %s)\n",
+		balStyle(fmt.Sprintf("%+.0f", st.Power.BalanceKW)),
+		balStyle(fmt.Sprintf("%.0f%%", st.Power.ReservePct))))
+	return b.String()
+}
+
+func renderResourceRunways(s Styler, st protocol.VaultState) string {
+	var b strings.Builder
+	b.WriteString(s.Subtitle("RESOURCE RUNWAY"))
+	b.WriteString("\n")
+	for _, r := range st.Resources {
+		if r.DailyUse <= 0 {
+			continue
+		}
+		runway := "∞"
+		if r.RunwayDays >= 0 {
+			runway = fmt.Sprintf("%dd", r.RunwayDays)
+		}
+		st := statusStyle(s, r.Status)
+		b.WriteString(fmt.Sprintf("  %-10s %s\n", r.Label, st(runway+"  ("+r.Status+")")))
+	}
+	return b.String()
+}
+
+func renderAlertLine(s Styler, a protocol.Alert) string {
+	tag := statusStyleByLevel(s, a.Level)
+	ack := ""
+	if a.Acknowledged {
+		ack = s.Muted(" [ack]")
+	}
+	return tag("["+string(a.Level)+"]") + " " + a.Message + ack
+}
+
+func renderEventLine(s Styler, e protocol.EventRecord, width int) string {
+	ts := e.VaultTime.Format("01-02 15:04")
+	line := fmt.Sprintf("%s  %-10s %s", s.Muted(ts), e.Category, e.Summary)
+	style := statusStyleByLevel(s, e.Severity)
+	if e.Severity == protocol.AlertInfo {
+		return line
+	}
+	return style(line)
+}
+
+func statusStyle(s Styler, status string) func(string) string {
+	switch status {
+	case "CRITICAL":
+		return s.Error
+	case "WARNING":
+		return s.Warning
+	case "WATCH":
+		return s.Accent
+	default:
+		return s.Success
+	}
+}
+
+func statusStyleByLevel(s Styler, level protocol.AlertLevel) func(string) string {
+	switch level {
+	case protocol.AlertCritical:
+		return s.Error
+	case protocol.AlertWarning:
+		return s.Warning
+	default:
+		return s.Accent
+	}
+}
+
+func formatScale(scale float64) string {
+	if scale == 0 {
+		return "frozen"
+	}
+	return fmt.Sprintf("%.0fx", scale)
+}
+
+// joinColumns places two multi-line blocks side by side within width.
+func joinColumns(left, right string, width int) string {
+	half := width / 2
+	leftLines := strings.Split(left, "\n")
+	rightLines := strings.Split(right, "\n")
+	n := len(leftLines)
+	if len(rightLines) > n {
+		n = len(rightLines)
+	}
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		l, r := "", ""
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+		pad := half - displayWidth(l)
+		if pad < 1 {
+			pad = 1
+		}
+		b.WriteString(l)
+		b.WriteString(strings.Repeat(" ", pad))
+		b.WriteString(r)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// displayWidth approximates rendered width, ignoring ANSI escape sequences.
+func displayWidth(s string) int {
+	n := 0
+	inEscape := false
+	for _, r := range s {
+		switch {
+		case r == '\x1b':
+			inEscape = true
+		case inEscape && r == 'm':
+			inEscape = false
+		case inEscape:
+			// skip
+		default:
+			n++
+		}
+	}
+	return n
+}

--- a/internal/tui/views/simulation/control_test.go
+++ b/internal/tui/views/simulation/control_test.go
@@ -1,0 +1,86 @@
+package simulation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vtuos/vtuos/internal/protocol"
+)
+
+// plainStyler renders without any styling so tests can assert on content.
+type plainStyler struct{}
+
+func (plainStyler) Title(s string) string    { return s }
+func (plainStyler) Subtitle(s string) string { return s }
+func (plainStyler) Label(s string) string    { return s }
+func (plainStyler) Value(s string) string    { return s }
+func (plainStyler) Muted(s string) string    { return s }
+func (plainStyler) Success(s string) string  { return s }
+func (plainStyler) Warning(s string) string  { return s }
+func (plainStyler) Error(s string) string    { return s }
+func (plainStyler) Accent(s string) string   { return s }
+func (plainStyler) Bar(v, m float64, w int) string {
+	return fmt.Sprintf("[%.0f/%.0f]", v, m)
+}
+
+func sampleState() protocol.VaultState {
+	now := time.Date(2080, 5, 1, 12, 0, 0, 0, time.UTC)
+	return protocol.VaultState{
+		SchemaVersion: protocol.Version,
+		Status:        protocol.SimRunning,
+		TimeScale:     60,
+		VaultTime:     now,
+		TickCount:     1234,
+		ElapsedYears:  2,
+		ElapsedDays:   190,
+		Population: protocol.PopulationStatus{
+			Active: 480, Capacity: 500, Births: 12, Deaths: 7, AverageAge: 31.4, LoadPct: 96,
+		},
+		Systems: protocol.SystemsSummary{
+			Total: 15, Operational: 12, Degraded: 2, Failed: 1, AvgEfficiency: 84.2, OverdueMaint: 1,
+		},
+		Power: protocol.PowerStatus{GenerationKW: 500, ConsumptionKW: 320, BalanceKW: 180, ReservePct: 36},
+		Resources: []protocol.ResourceStatus{
+			{Category: "FOOD", Label: "Food", DailyUse: 120, RunwayDays: 95, Status: "WATCH"},
+			{Category: "WATER", Label: "Water", DailyUse: 1440, RunwayDays: 25, Status: "WARNING"},
+		},
+	}
+}
+
+func TestControlViewRender(t *testing.T) {
+	v := NewControlView()
+	st := sampleState()
+	alerts := []protocol.Alert{
+		{Code: "POWER_RESERVE_LOW", Level: protocol.AlertWarning, Message: "Power reserve low"},
+	}
+	events := []protocol.EventRecord{
+		{VaultTime: st.VaultTime, Category: "FACILITY", Type: "SYSTEM_DEGRADED", Severity: protocol.AlertWarning, Summary: "Hydroponics Bay A degraded"},
+	}
+
+	out := v.Render(plainStyler{}, st, events, alerts, 100, 40)
+
+	for _, want := range []string{
+		"SIMULATION CONTROL CORE",
+		"RUNNING",
+		"POWER BALANCE",
+		"RESOURCE RUNWAY",
+		"ACTIVE ALERTS",
+		"OPERATIONAL EVENT LOG",
+		"Power reserve low",
+		"Hydroponics Bay A degraded",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("control view output missing %q", want)
+		}
+	}
+}
+
+func TestControlViewNoAlerts(t *testing.T) {
+	v := NewControlView()
+	out := v.Render(plainStyler{}, sampleState(), nil, nil, 100, 40)
+	if !strings.Contains(out, "No active alerts") {
+		t.Error("expected nominal message when there are no alerts")
+	}
+}

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -148,12 +148,15 @@ func ParseISO8601(s string) (time.Time, error) {
 	return time.Parse(ISO8601Format, s)
 }
 
-// CalculateAge calculates age in years from date of birth.
+// CalculateAge calculates age in years from date of birth. The birthday check
+// compares calendar month and day (rather than day-of-year) so leap years do
+// not introduce an off-by-one error.
 func CalculateAge(dob time.Time, asOf time.Time) int {
 	years := asOf.Year() - dob.Year()
 
 	// Adjust if birthday hasn't occurred yet this year
-	if asOf.YearDay() < dob.YearDay() {
+	if asOf.Month() < dob.Month() ||
+		(asOf.Month() == dob.Month() && asOf.Day() < dob.Day()) {
 		years--
 	}
 

--- a/testdata/vault-exhibit.toml
+++ b/testdata/vault-exhibit.toml
@@ -1,0 +1,83 @@
+# VT-UOS Configuration File
+# Vault-Tec Unified Operating System
+#
+# Interactive-exhibit configuration. Enables the boot sequence, unattended
+# attract (kiosk) mode, accelerated time, and the master server with its web
+# administration console. Deploy one master with `vtuos serve` and any number of
+# display terminals with `vtuos connect <master-address>`.
+
+[vault]
+designation = "Vault 076"
+number = 76
+region = "Appalachia"
+commissioned_date = "2076-10-23"
+sealed_date = "2077-10-23T09:47:00Z"
+designed_capacity = 500
+vault_type = "control"
+
+[vault.location]
+latitude = 39.6295
+longitude = -79.9559
+depth_meters = 100
+
+[overseer]
+initial_overseer_id = ""
+
+[experiment]
+enabled = false
+protocol_id = ""
+protocol_name = ""
+classification = "NONE"
+
+[simulation]
+enabled = true
+# Accelerated so an exhibit visibly progresses: 1 real minute ~= 1 vault day.
+time_scale = 1440.0
+auto_events = true
+event_frequency = "normal"
+start_date = "2077-10-23T09:47:00Z"
+
+[simulation.consumption]
+calorie_variance = 0.1
+water_variance = 0.1
+efficiency_decay_rate = 0.001
+
+[display]
+color_scheme = "green_phosphor"
+scan_lines = true
+flicker = false
+date_format = "2006-01-02"
+time_format = "15:04:05"
+
+[logging]
+level = "info"
+file = "logs/vtuos.log"
+max_size_mb = 10
+max_backups = 5
+
+[database]
+path = "vault.db"
+backup_interval_hours = 24
+backup_retention_days = 30
+
+[exhibit]
+# Presentation features for an unattended exhibit kiosk.
+boot_sequence = true
+attract_mode = true
+attract_idle_seconds = 90
+rotate_seconds = 12
+# Kiosk mode disables the quit confirmation so visitors cannot close the display.
+kiosk = true
+
+[server]
+# Master server: authoritative simulation, JSON/SSE API, and web admin console.
+listen = ":8080"
+admin_token = "change-me-overseer-token"
+enable_web = true
+heartbeat_seconds = 5
+client_timeout_seconds = 20
+
+[client]
+# Defaults applied when this binary runs as `vtuos connect`.
+name = "Atrium Display"
+kind = "DISPLAY"


### PR DESCRIPTION
## Summary

This PR implements the simulation control core (`internal/simulation`), the master server mode (`vtuos serve`), and client terminal mode (`vtuos connect`), completing Phase 5 of the development roadmap. The application now supports three deployment topologies:

1. **Local operator console** (`vtuos`) - TUI with in-process control core
2. **Master server** (`vtuos serve`) - Authoritative core + JSON/SSE API + web console
3. **Client terminal** (`vtuos connect <addr>`) - Remote display driven by master

## Key Changes

### Simulation Control Core (`internal/simulation/`)
- **engine.go** - Authoritative engine that advances vault time, processes consumption/degradation/incidents, publishes operational snapshots
- **tick.go** - Time advancement logic (hourly progression, daily accounting cycles)
- **consumption.go** - Daily resource draw (water, food by calories, medical supplies)
- **degradation.go** - System wear, efficiency thresholds, maintenance scheduling
- **incidents.go** - Weighted incident generation (equipment faults, contamination, illness, discoveries)
- **demographics.go** - Vital statistics (births, deaths) with daily probabilities
- **metrics.go** - Operational snapshot building (population, resources, systems, power balance)
- **alerts.go** - Alert evaluation (resource shortfalls, system failures, population viability)
- **events.go** - Event recording to in-memory feed and persistent database
- **persistence.go** - State save/restore across restarts
- **systems_seed.go** - Core facility system reference data
- **snapshot.go** - Database backup capability
- **engine_test.go** - Comprehensive test suite with deterministic seeding

### Protocol & Wire Types (`internal/protocol/`)
- **protocol.go** - Dependency-free types for operational state (VaultState, SimStatus, Alert, EventRecord, ClientInfo, Command, CommandResult)

### Master Server (`internal/server/`)
- **server.go** - HTTP server with JSON API and SSE streaming
- **api.go** - Read endpoints (health, state, status) and control endpoints (pause, resume, step, snapshot)
- **sse.go** - Server-Sent Events for live state streaming to clients
- **clients.go** - Client registry with registration, heartbeat, command queue, telemetry
- **auth.go** - Token-based admin authentication
- **web.go** - Embedded web console (HTML template + static assets)
- **server_test.go** - Integration tests

### Client Terminal (`internal/client/`)
- **client.go** - Bubble Tea model for remote display terminal
- **transport.go** - HTTP transport with registration, heartbeat, state subscription
- **view.go** - Dashboard, systems, resources, events, population views

### TUI Enhancements
- **app.go** - Added simulation engine attachment, exhibit mode (boot sequence, kiosk, attract mode), alert separation (user vs engine), simulation view integration
- **simadapter.go** - Theme adapter for simulation control view
- **views/simulation/control.go** - Simulation control console rendering (status, metrics, event feed, alerts)
- **views/simulation/control_test.go** - Control view tests
- **keys.go** - Added F11 key binding

### Configuration (`internal/config/`)
- Added `ExhibitConfig` (boot sequence, kiosk mode, attract timeout)
- Added `ServerConfig` (listen address, admin token, client timeout, web console)
- Added `ClientConfig` (master address, heartbeat interval)
- Added `SimulationConfig` (time scale, auto-events, event frequency, consumption variance, efficiency decay)

### Main Entry Point (`cmd/vtuos/main.go`)
- Refactored to dispatch three subcommands: local (default), `serve`, `connect`
- **localMain()** - Operator console with optional engine attachment
- **serveMain()** - Master server initialization and HTTP listener
- **connectMain()** - Client terminal registration and event loop
- Shared signal handling with graceful shutdown

### Documentation
- **docs/DEPLOYMENT.md** - Topology guide, deployment patterns, configuration examples